### PR TITLE
Fix bug with API and make implementation consistent with the docs.

### DIFF
--- a/src/api/crud.py
+++ b/src/api/crud.py
@@ -35,9 +35,13 @@ DF_EXPORT_FUNCS = {
 
 
 def apply_filters(query: Query, filters: str) -> Query:
+    comparator_names = list(comparator_map.keys())
+    comparator_names = ["\$" + name + ':' for name in comparator_names]
+    comparator_names = '|'.join(comparator_names)
+
     filters = [
         re.split(
-            "(\$eq:|\$neq:|\$lte:|\$gte:|\$lt:|\$gt:|\$isNull:|\$isNotNull:|\$contains:)",
+            f"({comparator_names})",
             item,
         )
         for item in filters
@@ -93,6 +97,7 @@ def create_aggregate_columns(aggregates):
     agg_funcs = [item.split("$") for item in aggregates]
     parts = []
     for name, func_name in agg_funcs:
+        func_name = func_name.replace(':', '')
         part = aggregate_map[func_name](column(name))
         if func_name != "distinct":
             part = part.label(f"{func_name}_{name}")

--- a/src/api/utils.py
+++ b/src/api/utils.py
@@ -91,8 +91,8 @@ comparator_map = {
     "neq": lambda column, value: column != value,
     "lt": lambda column, value: column < value,
     "gt": lambda column, value: column > value,
-    "lte": lambda column, value: column <= value,
-    "gte": lambda column, value: column >= value,
+    "leq": lambda column, value: column <= value,
+    "geq": lambda column, value: column >= value,
 }
 
 aggregate_map = {

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -20,6 +20,11 @@ def test_get_shots(client):
     assert len(data) == 50
     assert response.headers["x-total-pages"] == "368"
 
+def test_get_shots_filter_shot_id(client):
+    response = client.get("json/shots?filters=shot_id$leq:30000")
+    data = response.json()
+    assert response.status_code == 200
+    assert len(data) == 50
 
 def test_get_shot(client):
     response = client.get("json/shots/30420")
@@ -27,10 +32,9 @@ def test_get_shot(client):
     assert response.status_code == 200
     assert data["shot_id"] == 30420
 
-
 def test_get_shot_aggregate(client):
     response = client.get(
-        "json/shots/aggregate?data=shot_id$min,shot_id$max&groupby=campaign&sort=-min_shot_id"
+        "json/shots/aggregate?data=shot_id$min:,shot_id$max:&groupby=campaign&sort=-min_shot_id"
     )
     data = response.json()
     assert response.status_code == 200
@@ -40,7 +44,7 @@ def test_get_shot_aggregate(client):
 
 def test_get_signal_datasets_aggregate(client):
     response = client.get(
-        "json/signal_datasets/aggregate?data=name$count&groupby=quality"
+        "json/signal_datasets/aggregate?data=name$count:&groupby=quality"
     )
     data = response.json()
     assert response.status_code == 200
@@ -48,7 +52,7 @@ def test_get_signal_datasets_aggregate(client):
 
 
 def test_get_signals_aggregate(client):
-    response = client.get("json/signals/aggregate?data=shot_id$count&groupby=quality")
+    response = client.get("json/signals/aggregate?data=shot_id$count:&groupby=quality")
     data = response.json()
     assert response.status_code == 200
     assert len(data) == 1


### PR DESCRIPTION
Fixes two small issues:

1. The API was broken for aggregate filtering when the operators use a colon (e.g. `shot_id$leq:30000`)
2. The API and docs were inconsistent when using the <= and >= operator names.

Both of these should now be fixed. I have also added a new unit test to cover this case.

To test:

- Code review: Check the code is sensible and fixes the describe issue
- Run the unit tests/check the example query is fixed. 