### PR TITLE
Use UV in dockerfile 

### DIFF
--- a/dev/docker/api.Dockerfile
+++ b/dev/docker/api.Dockerfile
@@ -1,9 +1,12 @@
 FROM python:3.11
 WORKDIR /code
 
+ADD --chmod=755 https://astral.sh/uv/install.sh /install.sh
+RUN /install.sh && rm /install.sh
+
 COPY ./requirements.txt /code/requirements.txt
 
-RUN pip install --no-cache-dir --upgrade -r /code/requirements.txt
+RUN /root/.cargo/bin/uv pip install --system --no-cache -r /code/requirements.txt
 
 COPY ./src /code/src
 


### PR DESCRIPTION
Changed it so on the podman set up, uv is used instead of pip install. Following example here: https://ryxcommar.com/2024/02/15/how-to-cut-your-python-docker-builds-in-half-with-uv/

- Build the image and run tests.