### PR TITLE
taken out default cache

### DIFF
--- a/src/api/static/intake/level1.yml
+++ b/src/api/static/intake/level1.yml
@@ -13,7 +13,7 @@ sources:
         type: str
         default: ""
       cache_type:
-        description: Type of caching to use with s3. Defaults to "simplecache"
+        description: Type of caching to use with s3. Defaults to "filecache"
         type: str
         default: "filecache"
     args:
@@ -35,7 +35,7 @@ sources:
         type: str
         default: ""
       cache_type:
-        description: Type of caching to use with s3. Defaults to "simplecache"
+        description: Type of caching to use with s3. Defaults to "filecache"
         type: str
         default: "filecache"
     args:

--- a/src/api/static/intake/level1.yml
+++ b/src/api/static/intake/level1.yml
@@ -13,9 +13,9 @@ sources:
         type: str
         default: ""
       cache_type:
-        description: Type of caching to use with s3. Defaults to "filecache"
+        description: Type of caching to use with s3. Defaults to "simplecache"
         type: str
-        default: "filecache"
+        default: "simplecache"
     args:
       urlpath: "{{cache_type}}::{{url}}/{{group}}"
       consolidated: True
@@ -35,9 +35,9 @@ sources:
         type: str
         default: ""
       cache_type:
-        description: Type of caching to use with s3. Defaults to "filecache"
+        description: Type of caching to use with s3. Defaults to "simplecache"
         type: str
-        default: "filecache"
+        default: "simplecache"
     args:
       urlpath: "{{cache_type}}::{{url}}"
       consolidated: True

--- a/src/api/static/intake/level1.yml
+++ b/src/api/static/intake/level1.yml
@@ -15,7 +15,7 @@ sources:
       cache_type:
         description: Type of caching to use with s3. Defaults to "simplecache"
         type: str
-        default: "simplecache"
+        default: "filecache"
     args:
       urlpath: "{{cache_type}}::{{url}}/{{group}}"
       consolidated: True
@@ -37,7 +37,7 @@ sources:
       cache_type:
         description: Type of caching to use with s3. Defaults to "simplecache"
         type: str
-        default: "simplecache"
+        default: "filecache"
     args:
       urlpath: "{{cache_type}}::{{url}}"
       consolidated: True

--- a/src/api/static/intake/level1.yml
+++ b/src/api/static/intake/level1.yml
@@ -16,10 +16,6 @@ sources:
         description: Type of caching to use with s3. Defaults to "simplecache"
         type: str
         default: "simplecache"
-      cache_dir:
-        description: Location to cache remote data locally.
-        type: str
-        default: "/tmp"
     args:
       urlpath: "{{cache_type}}::{{url}}/{{group}}"
       consolidated: True
@@ -27,7 +23,6 @@ sources:
         s3:
           anon: true
           endpoint_url: "https://s3.echo.stfc.ac.uk"
-        cache_storage: "{{cache_dir}}"
   sources:
     driver: intake_xarray.xzarr.ZarrSource
     description: "Source data from the MAST tokamak"
@@ -43,10 +38,6 @@ sources:
         description: Type of caching to use with s3. Defaults to "simplecache"
         type: str
         default: "simplecache"
-      cache_dir:
-        description: Location to cache remote data locally.
-        type: str
-        default: "/tmp"
     args:
       urlpath: "{{cache_type}}::{{url}}"
       consolidated: True
@@ -54,4 +45,3 @@ sources:
         s3:
           anon: true
           endpoint_url: "https://s3.echo.stfc.ac.uk"
-        cache_storage: "{{cache_dir}}"


### PR DESCRIPTION
To solve issues: #73 and #74  
Issue is where windows users fails due to the catalog file, which takes in level1.yml setting cache location to /tmp. Assumption was made by group that taking out cache_dir from yaml file would make os choose it's default temp file. 
Test by taking out and seeing it cache is working. When loaded first, takes some time, when loaded second is instantaneous. This worked for me on Mac OS, need to test with Windows OS to ensure the same results.

Way I tested:

catalog_local = intake.open_catalog('src/api/static/intake/catalog.yml')

url = "s3://mast/level1/shots/30467.zarr/amc"
dataset_local = catalog_local.level1.sources(url=url)
dataset_local.read()

All fairly quick, slight delay on the dataset.read()

After doing again,
dataset_local.read() and
dataset_local.to_dask()

Happened instantaneously, hence cache is fine.

Compared to normal way with mastapp catalog files:

catalog_mastapp = intake.open_catalog('https://mastapp.site/intake/catalog.yml')

dataset_mastapp = catalog_mastapp.level1.sources(url‎ = url)
dataset_mastapp.read()

All happened the same as local, fairly quick apart from .read()

After doing again,
dataset_mastapp.read() and
dataset_mastapp.to_dask()

Happened instantaneously, exactly the same as the local version.