### PR TITLE
Ci lfs fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 name: CI
-on: [ pull_request ]
+on: [ push, pull_request ]
 
 jobs:
   build-and-run-tests:
@@ -36,8 +36,9 @@ jobs:
 
     - name: Set up environment
       run: |
-        git lfs fetch
-        git lfs pull
+        export AWS_ACCESS_KEY_ID=${{ secrets.STFC_ACCESS_KEY }}
+        export AWS_ACCESS_KEY_ID=${{ secrets.STFC_SECRET_ACCESS_KEY }}
+        s5cmd --endpoint-url https://s3.echo.stfc.ac.uk cp "s3://mast/dev/" .
         pip install --upgrade pip
         pip install uv
         uv sync 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 name: CI
-on: [ push, pull_request ]
+on: [ pull_request ]
 
 jobs:
   build-and-run-tests:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       run: |
         export AWS_ACCESS_KEY_ID=${{ secrets.STFC_ACCESS_KEY }}
         export AWS_SECRET_ACCESS_KEY=${{ secrets.STFC_SECRET_ACCESS_KEY }}
-        s5cmd --endpoint-url https://s3.echo.stfc.ac.uk cp "s3://mast/dev/mock_data*" tests/
+        s5cmd --endpoint-url https://s3.echo.stfc.ac.uk cp "s3://mast/dev/mock_data*" .
         ls
         pip install --upgrade pip
         pip install uv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Set up environment
       run: |
         export AWS_ACCESS_KEY_ID=${{ secrets.STFC_ACCESS_KEY }}
-        export AWS_ACCESS_KEY_ID=${{ secrets.STFC_SECRET_ACCESS_KEY }}
+        export AWS_SECRET_ACCESS_KEY=${{ secrets.STFC_SECRET_ACCESS_KEY }}
         s5cmd --endpoint-url https://s3.echo.stfc.ac.uk cp "s3://mast/dev/mock_data*" .
         pip install --upgrade pip
         pip install uv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       run: |
         export AWS_ACCESS_KEY_ID=${{ secrets.STFC_ACCESS_KEY }}
         export AWS_ACCESS_KEY_ID=${{ secrets.STFC_SECRET_ACCESS_KEY }}
-        s5cmd --endpoint-url https://s3.echo.stfc.ac.uk cp "s3://mast/dev/" .
+        s5cmd --endpoint-url https://s3.echo.stfc.ac.uk cp "s3://mast/dev/mock_data*" .
         pip install --upgrade pip
         pip install uv
         uv sync 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       run: |
         export AWS_ACCESS_KEY_ID=${{ secrets.STFC_ACCESS_KEY }}
         export AWS_SECRET_ACCESS_KEY=${{ secrets.STFC_SECRET_ACCESS_KEY }}
-        s5cmd --endpoint-url https://s3.echo.stfc.ac.uk cp "s3://mast/dev/mock_data*" .
+        s5cmd --endpoint-url https://s3.echo.stfc.ac.uk cp "s3://mast/dev/mock_data*" tests/
         ls
         pip install --upgrade pip
         pip install uv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       uses: docker/setup-buildx-action@v1
 
     - name: Cache Docker layers
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: /tmp/.buildx-cache
         key: ${{ runner.os }}-buildx-${{ github.sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,11 @@ jobs:
         --build \
         -d 
 
+    - name: Set-up s5cmd
+      uses: peak/action-setup-s5cmd@main
+      with:
+        version: v2.0.0
+
     - name: Set up environment
       run: |
         export AWS_ACCESS_KEY_ID=${{ secrets.STFC_ACCESS_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,8 +43,7 @@ jobs:
       run: |
         export AWS_ACCESS_KEY_ID=${{ secrets.STFC_ACCESS_KEY }}
         export AWS_SECRET_ACCESS_KEY=${{ secrets.STFC_SECRET_ACCESS_KEY }}
-        s5cmd --endpoint-url https://s3.echo.stfc.ac.uk cp "s3://mast/dev/mock_data*" tests/
-        ls
+        s5cmd --endpoint-url https://s3.echo.stfc.ac.uk cp "s3://mast/dev/mock_data*" .
         pip install --upgrade pip
         pip install uv
         uv sync 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       run: |
         export AWS_ACCESS_KEY_ID=${{ secrets.STFC_ACCESS_KEY }}
         export AWS_SECRET_ACCESS_KEY=${{ secrets.STFC_SECRET_ACCESS_KEY }}
-        s5cmd --endpoint-url https://s3.echo.stfc.ac.uk cp "s3://mast/dev/mock_data*" .
+        s5cmd --endpoint-url https://s3.echo.stfc.ac.uk cp "s3://mast/dev/mock_data*" tests/
         pip install --upgrade pip
         pip install uv
         uv sync 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,7 @@ jobs:
         export AWS_ACCESS_KEY_ID=${{ secrets.STFC_ACCESS_KEY }}
         export AWS_SECRET_ACCESS_KEY=${{ secrets.STFC_SECRET_ACCESS_KEY }}
         s5cmd --endpoint-url https://s3.echo.stfc.ac.uk cp "s3://mast/dev/mock_data*" tests/
+        ls
         pip install --upgrade pip
         pip install uv
         uv sync 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "fastapi>=0.115.2",
     "jinja2>=3.1.4",
     "numpy<2",
-    "pandas==2.0.3",
+    "pandas==2.1.4",
     "psycopg2-binary>=2.9.10",
     "pyarrow>=17.0.0",
     "sqlakeyset>=2.0.1726021475",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ def pytest_addoption(parser):
     parser.addoption(
         "--data-path",
         action="store",
-        default="./tests/mock_data/index",
+        default="mock_data/index",
         help="Path to mini data directory",
     )
 


### PR DESCRIPTION
fixes #121 

I have removed needing to use git LFS from our CI, and instead it uses `s5cmd` to pull data from the STFC S3 bucket.

Due to this change, I have changed the data path in the conftest.py from `./tests/mock_data...` to `mock_data/...`.  This is because of permissions within the container not letting my copy into the tests/ dir

Please review:
- Sensible changes in the CI
- This PR should run the CI, so make sure its green :) 

As for running pytest locally, I will add an instruction to pull the mock_data from S3 to the local repo. I have tested this already but will do another PR for that.