### PR TITLE
fix: database data ingestion broken link

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,9 +30,7 @@ jobs:
         sudo mkdir -p tests/mock_data
         sudo chown -R runner:runner tests/mock_data
         sudo chmod -R 755 tests/mock_data
-    - name: check who the runner is
-      run: whoami
-      
+        
     - name: Build and run containers
       run: |
         docker compose \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,11 @@ jobs:
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
+
+    - name: Set-up s5cmd
+      uses: peak/action-setup-s5cmd@main
+      with:
+        version: v2.0.0
     
     - name: Setup environment and prepare dir
       run: |
@@ -44,11 +49,6 @@ jobs:
         up \
         --build \
         -d 
-
-    - name: Set-up s5cmd
-      uses: peak/action-setup-s5cmd@main
-      with:
-        version: v2.0.0
   
     - name: Run tests
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,11 +25,16 @@ jobs:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
     
-    - name: Create mock data dir if missing
+    - name: Setup environment and prepare dir
       run: |
         sudo mkdir -p tests/mock_data
         sudo chown -R runner:runner tests/mock_data
-        sudo chmod -R 755 tests/mock_data
+        # sudo chmod -R 755 tests/mock_data
+        s5cmd --no-sign-request --endpoint-url https://s3.echo.stfc.ac.uk cp "s3://mast/dev/mock_data*" ./tests
+        pip install --upgrade pip
+        pip install uv
+        uv sync 
+
         
     - name: Build and run containers
       run: |
@@ -44,13 +49,6 @@ jobs:
       uses: peak/action-setup-s5cmd@main
       with:
         version: v2.0.0
-
-    - name: Set up environment
-      run: |
-        s5cmd --no-sign-request --endpoint-url https://s3.echo.stfc.ac.uk cp "s3://mast/dev/mock_data*" ./tests
-        pip install --upgrade pip
-        pip install uv
-        uv sync 
   
     - name: Run tests
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,10 @@ jobs:
         up \
         --build \
         -d 
-
+    - name: Change folders permissions
+      run: |
+        chmod -R 755 ./tests/mock_data
+        
     - name: Set-up s5cmd
       uses: peak/action-setup-s5cmd@main
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
 
     - name: Set up environment
       run: |
-        s5cmd --no-sign-request --endpoint-url https://s3.echo.stfc.ac.uk cp "s3://mast/dev/mock_data*" .
+        s5cmd --no-sign-request --endpoint-url https://s3.echo.stfc.ac.uk cp "s3://mast/dev/mock_data*" ./tests
         pip install --upgrade pip
         pip install uv
         uv sync 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,9 +33,8 @@ jobs:
         up \
         --build \
         -d 
-    - name: Change folders ownership
-      run: |
-        sudo chown -R 1000:1000 ./tests/mock_data
+    - name: Create mock data dir if missing
+      run: sudo mkdir -p ./tests/mock_data/index/cpf 
 
     - name: Set-up s5cmd
       uses: peak/action-setup-s5cmd@main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,13 @@ jobs:
         password: ${{ secrets.DOCKER_PASSWORD }}
     
     - name: Create mock data dir if missing
-      run: sudo mkdir -p tests/mock_data/
-
+      run: |
+        sudo mkdir -p tests/mock_data
+        sudo chown -R runner:runner tests/mock_data
+        sudo chmod -R 755 tests/mock_data
+    - name: check who the runner is
+      run: whoami
+      
     - name: Build and run containers
       run: |
         docker compose \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,8 @@ jobs:
         -d 
     - name: Change folders permissions
       run: |
-        chmod -R 755 ./tests/mock_data
-        
+        sudo chmod -R 755 ./tests/mock_data
+
     - name: Set-up s5cmd
       uses: peak/action-setup-s5cmd@main
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,6 @@ jobs:
       run: |
         sudo mkdir -p tests/mock_data
         sudo chown -R runner:runner tests/mock_data
-        # sudo chmod -R 755 tests/mock_data
         s5cmd --no-sign-request --endpoint-url https://s3.echo.stfc.ac.uk cp "s3://mast/dev/mock_data*" ./tests
         pip install --upgrade pip
         pip install uv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,9 @@ jobs:
       with:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
+    
+    - name: Create mock data dir if missing
+      run: sudo mkdir -p tests/mock_data/
 
     - name: Build and run containers
       run: |
@@ -33,8 +36,6 @@ jobs:
         up \
         --build \
         -d 
-    - name: Create mock data dir if missing
-      run: sudo mkdir -p ./tests/mock_data/index/cpf 
 
     - name: Set-up s5cmd
       uses: peak/action-setup-s5cmd@main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,9 +33,9 @@ jobs:
         up \
         --build \
         -d 
-    - name: Change folders permissions
+    - name: Change folders ownership
       run: |
-        sudo chmod -R 755 ./tests/mock_data
+        sudo chown -R 1000:1000 ./tests/mock_data
 
     - name: Set-up s5cmd
       uses: peak/action-setup-s5cmd@main

--- a/.gitignore
+++ b/.gitignore
@@ -162,7 +162,7 @@ cython_debug/
 #
 data
 s3data
-mock_data/
+tests/*
 
 experiments/data/*
 experiments/results/*

--- a/.gitignore
+++ b/.gitignore
@@ -162,7 +162,7 @@ cython_debug/
 #
 data
 s3data
-mock_data
+mock_data/
 
 experiments/data/*
 experiments/results/*

--- a/.gitignore
+++ b/.gitignore
@@ -162,7 +162,7 @@ cython_debug/
 #
 data
 s3data
-tests/mock_data/*
+mock_data/*
 
 experiments/data/*
 experiments/results/*

--- a/.gitignore
+++ b/.gitignore
@@ -164,6 +164,9 @@ data
 s3data
 tests/mock_data/index/**
 
+!tests/mock_data/
+!tests/mock_data/.gitkeep
+
 experiments/data/*
 experiments/results/*
 dask-scratch-space

--- a/.gitignore
+++ b/.gitignore
@@ -162,7 +162,10 @@ cython_debug/
 #
 data
 s3data
-mock_data/*
+tests/mock_data/**
+
+# !tests/mock_data/
+# !tests/mock_data/.gitkeep
 
 experiments/data/*
 experiments/results/*

--- a/.gitignore
+++ b/.gitignore
@@ -162,10 +162,7 @@ cython_debug/
 #
 data
 s3data
-tests/mock_data/index/**
-
-!tests/mock_data/
-!tests/mock_data/.gitkeep
+tests/mock_data/**
 
 experiments/data/*
 experiments/results/*

--- a/.gitignore
+++ b/.gitignore
@@ -162,7 +162,7 @@ cython_debug/
 #
 data
 s3data
-tests/*
+tests/mock_data/*
 
 experiments/data/*
 experiments/results/*

--- a/.gitignore
+++ b/.gitignore
@@ -162,10 +162,7 @@ cython_debug/
 #
 data
 s3data
-tests/mock_data/**
-
-# !tests/mock_data/
-# !tests/mock_data/.gitkeep
+tests/mock_data/index/**
 
 experiments/data/*
 experiments/results/*

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ cd fair-mast
 Retrieve and ingest the metadata files using [s5cmd](https://github.com/peak/s5cmd):
 
 ```
-s5cmd --no-sign-request --endpoint-url https://s3.echo.stfc.ac.uk cp "s3://mast/dev/mock_data*" .
+s5cmd --no-sign-request --endpoint-url https://s3.echo.stfc.ac.uk cp "s3://mast/dev/mock_data*" tests/
 ```
 
 Create the database and ingest data using the following command:

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ cd fair-mast
 Retrieve and ingest the metadata files using [s5cmd](https://github.com/peak/s5cmd):
 
 ```
-s5cmd --no-sign-request --endpoint-url https://s3.echo.stfc.ac.uk cp "s3://mast/dev/mock_data*" .
+s5cmd --no-sign-request --endpoint-url https://s3.echo.stfc.ac.uk cp "s3://mast/dev/mock_data*" ./tests
 ```
 
 Create the database and ingest data using the following command:

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ cd fair-mast
 Retrieve and ingest the metadata files using [s5cmd](https://github.com/peak/s5cmd):
 
 ```
-s5cmd --no-sign-request --endpoint-url https://s3.echo.stfc.ac.uk cp "s3://mast/dev/mock_data*" tests/
+s5cmd --no-sign-request --endpoint-url https://s3.echo.stfc.ac.uk cp "s3://mast/dev/mock_data*" .
 ```
 
 Create the database and ingest data using the following command:

--- a/dev/docker/docker-compose.yml
+++ b/dev/docker/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     image: mast-api:latest
     restart: always
     volumes:
-      - ../../tests/mock_data:/code/data
+      - ../../mock_data:/code/data
       - ../../data/index:/code/index
       - ../../src:/code/src
     ports:

--- a/dev/docker/docker-compose.yml
+++ b/dev/docker/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     image: mast-api:latest
     restart: always
     volumes:
-      - ../../mock_data:/code/data
+      - ../../tests/mock_data:/code/data
       - ../../data/index:/code/index
       - ../../src:/code/src
     ports:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ def pytest_addoption(parser):
     parser.addoption(
         "--data-path",
         action="store",
-        default="mock_data/index",
+        default="./tests/mock_data/index",
         help="Path to mini data directory",
     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ def pytest_addoption(parser):
     parser.addoption(
         "--data-path",
         action="store",
-        default="mock_data/index",
+        default="tests/mock_data/index",
         help="Path to mini data directory",
     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,7 @@ def pytest_addoption(parser):
     parser.addoption(
         "--data-path",
         action="store",
-        default="tests/mock_data/index",
+        default="mock_data/index",
         help="Path to mini data directory",
     )
 


### PR DESCRIPTION
fix data mount broken link in docker compose file
Fixes error that comes up when this is executed. 
`podman exec -it mast-api python -m src.api.create /code/data/index`