### PR TITLE
API docs link fixes

### DIFF
--- a/docs/rest_api.ipynb
+++ b/docs/rest_api.ipynb
@@ -14,7 +14,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": 1,
    "id": "ebba03b7-34c4-4b49-94d8-112c7176ac7f",
    "metadata": {},
    "outputs": [],
@@ -34,7 +34,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": 2,
    "id": "ecbd2ced",
    "metadata": {},
    "outputs": [
@@ -62,7 +62,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 53,
+   "execution_count": 3,
    "id": "a722af66-9731-4878-b2df-9c9ba7ac0be7",
    "metadata": {},
    "outputs": [
@@ -90,7 +90,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 54,
+   "execution_count": 4,
    "id": "2611f771",
    "metadata": {},
    "outputs": [
@@ -380,7 +380,7 @@
        " 'radii_magnetic:radius_efit': None}"
       ]
      },
-     "execution_count": 54,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -398,7 +398,7 @@
     "\n",
     "For more information on the what's returned by the API you can look at the endpoint documentation:\n",
     "\n",
-    "https://mast-app.site/redoc\n"
+    "https://mastapp.site/redoc\n"
    ]
   },
   {
@@ -411,7 +411,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 65,
+   "execution_count": 5,
    "id": "66c264c5",
    "metadata": {},
    "outputs": [
@@ -645,7 +645,7 @@
        "[5 rows x 281 columns]"
       ]
      },
-     "execution_count": 65,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -671,7 +671,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 67,
+   "execution_count": 6,
    "id": "ed99237a",
    "metadata": {},
    "outputs": [
@@ -905,7 +905,7 @@
        "[5 rows x 281 columns]"
       ]
      },
-     "execution_count": 67,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -937,7 +937,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 68,
+   "execution_count": 7,
    "id": "80d840d5-ccf4-4ed2-9fe4-33798f2ae62f",
    "metadata": {},
    "outputs": [
@@ -1084,7 +1084,7 @@
        "[2 rows x 281 columns]"
       ]
      },
-     "execution_count": 68,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1105,7 +1105,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "mast-book",
+   "display_name": ".venv",
    "language": "python",
    "name": "python3"
   },
@@ -1119,7 +1119,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.9"
+   "version": "3.12.7"
   }
  },
  "nbformat": 4,

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -286,6 +286,22 @@ def query_aggregate(
     items = db.execute(query).all()
     return items
 
+@app.get(
+    "/json",
+    description="Root of JSON API - shows available endpoints.",
+    response_class=CustomJSONResponse,  
+)
+def json_root():
+    return {
+        "message": "Welcome to the FAIR MAST API.",
+        "documentation_url": "https://mastapp.site/redoc",
+        "example_endpoints": [
+            "/json/shots",
+            "/json/cpf_summary",
+            "/json/scenarios",
+            "/json/sources",  
+        ]
+    }
 
 @app.get(
     "/json/shots",


### PR DESCRIPTION
Fix #141 and fix #142.

One typo in the docs that needed fixing, and added an endpoint for just `/json` containing link to the redocs and some example endpoints. Happy to add/remove anything from this.

To test:
- Run the `rest_api.ipynb` notebook.
- Run dev container of FAIR MAST, and check the endpoint `http://localhost:8081/json` returns the expected data. 
