### PR TITLE
docker exec data path fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,7 +162,7 @@ cython_debug/
 #
 data
 s3data
-tests/mock_data/**
+tests/mock_data
 
 tests/mock_data/index
 experiments/data/*

--- a/README.md
+++ b/README.md
@@ -83,13 +83,13 @@ Create the database and ingest data using the following command:
 - #### Mac Users
 
 ```bash
-podman exec -it mast-api python -m src.api.create /data/index
+podman exec -it mast-api python -m src.api.create /test_data/index/  
 ```
 
 - #### Linux/Windows Users
 
 ```bash
-docker exec -it mast-api python -m src.api.create /data/index
+docker exec -it mast-api python -m src.api.create /test_data/index/  
 ```
 
 ### ✅ Running Unit Tests

--- a/data/index/mast-level1-signals.parquet
+++ b/data/index/mast-level1-signals.parquet
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6134aad30b1ba2e0e47e78323553c0c4e1921628d76b0c4df3ac18958b566124
-size 606022945

--- a/data/index/mast-level1-sources.parquet
+++ b/data/index/mast-level1-sources.parquet
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:acd0eaf1ff574b2d9af01a3fae77072c6af10e0d0ffe2fe0ddd271a6701f60b0
-size 16549534

--- a/data/index/mast-level2-signals.parquet
+++ b/data/index/mast-level2-signals.parquet
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ea59a792963b7dc3bedd7bf4b6f787dd03dae2c55da9846f55c6b232dd1c3221
-size 34710463

--- a/data/index/mast-level2-sources.parquet
+++ b/data/index/mast-level2-sources.parquet
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:166e620566f0a7fe7a839442382cab3092e66c70ee389a31d2ed86066874b2c1
-size 4592736

--- a/data/index/mast_cpf_columns.parquet
+++ b/data/index/mast_cpf_columns.parquet
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:aec859036331a5c9e9f2a77cb680be5a3e3d227085388edd054e5d15f6950fd1
-size 9624

--- a/data/index/mast_cpf_data.parquet
+++ b/data/index/mast_cpf_data.parquet
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fa331c533c649f4dea6be0750cbb76bed7f26072dd8b5497d0aa94dafcc75920
-size 15422973

--- a/data/index/mastu-level2-signals.parquet
+++ b/data/index/mastu-level2-signals.parquet
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:531325c8914ce7f2045b02d61b93caf2195accf7008b8e0a0107e5acd414b8e4
-size 9429752

--- a/data/index/mastu-level2-sources.parquet
+++ b/data/index/mastu-level2-sources.parquet
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:17903a0d7e87a579a9f04aa03118ed06736e29bdad3caf440bd74fd09108df15
-size 1727261

--- a/data/index/mastu_cpf_columns.parquet
+++ b/data/index/mastu_cpf_columns.parquet
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:aec859036331a5c9e9f2a77cb680be5a3e3d227085388edd054e5d15f6950fd1
-size 9624

--- a/data/index/mastu_cpf_data.parquet
+++ b/data/index/mastu_cpf_data.parquet
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bef289347456765b0915be8d6fb985b9ec6b3fb077791914cf93bcb6c45b9f72
-size 6064970

--- a/data/index/shots.parquet
+++ b/data/index/shots.parquet
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f065fca59c81bb93832ec37498005c44e257f54dff95172b68f86e9f8ae0d0fc
-size 2347534


### PR DESCRIPTION
Seems the data path we use for the `podman exec` command was wrong. Should work to populate the database now.

- Follow set up instructions from the README and test the new data path works.


