### PR TITLE
remove redundant line in docs

### DIFF
--- a/docs/cpf_data.ipynb
+++ b/docs/cpf_data.ipynb
@@ -42,7 +42,6 @@
    "outputs": [],
    "source": [
     "summary = pd.read_parquet('https://mastapp.site/parquet/level2/shots')\n",
-    "summary = summary.loc[summary.shot_id <40000]\n",
     "summary"
    ]
   },


### PR DESCRIPTION
Taken out redundant line from cpf_data example from issue #169 