### PR TITLE
Add mastapp.site server for FastAPI docs

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -68,10 +68,6 @@ graphql_app = JSONLDGraphQL(
 )
 
 
-SITE_URL = "https://mastapp.site"
-if "VIRTUAL_HOST" in os.environ:
-    SITE_URL = f"https://{os.environ.get('VIRTUAL_HOST')}"
-
 DEFAULT_PER_PAGE = 100
 
 # Setup FastAPI Application

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -13,6 +13,7 @@ import ujson
 from fastapi import Depends, FastAPI, HTTPException, Query, Request, Response, status
 from fastapi.encoders import jsonable_encoder
 from fastapi.exceptions import RequestValidationError
+from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse, StreamingResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
@@ -67,14 +68,29 @@ graphql_app = JSONLDGraphQL(
 )
 
 
-SITE_URL = "http://localhost:8081"
+SITE_URL = "https://mastapp.site"
 if "VIRTUAL_HOST" in os.environ:
     SITE_URL = f"https://{os.environ.get('VIRTUAL_HOST')}"
 
 DEFAULT_PER_PAGE = 100
 
 # Setup FastAPI Application
-app = FastAPI(title="MAST Archive", servers=[{"url": SITE_URL}])
+app = FastAPI(
+    title="MAST Archive", 
+    servers=[
+        {"url": "https://mastapp.site", "description": "Production server"},
+        {"url": "http://localhost:8081", "description": "Local development server"}
+    ]
+)
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=[
+        "https://mastapp.site",
+        "http://localhost:8081", 
+    ],
+)
+
 app.add_route("/graphql", graphql_app)
 app.add_websocket_route("/graphql", graphql_app)
 add_pagination(app)


### PR DESCRIPTION
Our FastAPI doc (`https://mastapp.site/docs`) was using `localhost` as its server, and hence any GET requests made were returning an Internal Server Error.

I have added `mastapp.site` as a server option, and kept the `localhost` server too for development purposes. I also added CORS middleware, which allows GET requests between different "origins". More info on the [docs](https://fastapi.tiangolo.com/tutorial/cors/) here.

To test:
- Spin up the Docker environment and populate the database.
- Go to `http://localhost:8081/docs` and select the `localhost` server from the drop down box.
- Try out any of the GET requests, you should now get the correct responses and info.

P.S. I think we should be able to send GET requests to the `mastapp.site` server from a localhost instance of the docs, but only when the CORS middleware config is on the production server.