### PR TITLE
Fix FastAPI server 

### DIFF
--- a/dev/docker/docker-compose-prod.yml
+++ b/dev/docker/docker-compose-prod.yml
@@ -8,6 +8,8 @@ services:
     ports:
      - 80:80
      - 443:443
+    environment:
+      - VIRTUAL_HOST=mastapp.site
     volumes:
       - ${NGINX_CONFIG_PATH}:/etc/nginx/conf.d/default.conf
       - ./certbot/www/:/var/www/certbot/:ro


### PR DESCRIPTION
`VIRTUAL_HOST` had been removed in a previous commit, meaning that the FastAPI docs server has been defaulting to `localhost`, meaning the query executions in the docs do not work.

@DanielABrennand can you let me know if this change will be automatically put in with the CI/CD?

