### PR TITLE
Fixed formatting on certbot command

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -9,7 +9,7 @@ env:
   PGADMIN_USER=: ${{ secrets.PGADMIN_USER }} 
   PGADMIN_PASSWORD: ${{ secrets.PGADMIN_PASSWORD }} 
   NGINX_CONFIG_PATH: ./nginx.conf
-  CERTBOT_COMMAND: "/bin/sh -c 'certbot certonly --webroot --webroot-path /var/www/certbot/ --non-interactive -d mastapp.site -d www.mastapp.site --agree-tos --register-unsafely-without-email';'while :; do certbot renew; sleep 12h; done'"  
+  CERTBOT_COMMAND: "/bin/sh -c 'certbot certonly --webroot --webroot-path /var/www/certbot/ --non-interactive -d mastapp.site -d www.mastapp.site --agree-tos --register-unsafely-without-email; while :; do certbot renew; sleep 12h; done'"  
 
 jobs:
   remote_deployment:

--- a/dev/docker/.env.dev
+++ b/dev/docker/.env.dev
@@ -13,4 +13,4 @@ NGINX_CONFIG_PATH=./nginx-test.conf
 #Runs a test certification, here the certificates are not saved and doesn't count towards the weekly limit
 CERTBOT_COMMAND="/bin/sh -c 'certbot certonly --webroot --webroot-path /var/www/certbot/ --non-interactive -d mastapp.site -d www.mastapp.site --agree-tos --register-unsafely-without-email --dry-run'"
 #Run a real certification then attemts auto renewal every 12 hours
-#CERTBOT_COMMAND: "/bin/sh -c 'certbot certonly --webroot --webroot-path /var/www/certbot/ --non-interactive -d mastapp.site -d www.mastapp.site --agree-tos --register-unsafely-without-email';'while :; do certbot renew; sleep 12h; done'"  
+#CERTBOT_COMMAND: "/bin/sh -c 'certbot certonly --webroot --webroot-path /var/www/certbot/ --non-interactive -d mastapp.site -d www.mastapp.site --agree-tos --register-unsafely-without-email; while :; do certbot renew; sleep 12h; done'"  


### PR DESCRIPTION
Fixed the formatting on the certbot command which was causing its container to close instead of attempting a renewal every 12 hours.