### PR TITLE
Add aliases for parquet shots

### DIFF
--- a/src/api/main.py
+++ b/src/api/main.py
@@ -887,6 +887,11 @@ def query_to_parquet_bytes(db: Session, query: Query) -> bytes:
     if "uuid" in df:
         df["uuid"] = df["uuid"].map(str)
 
+    # ensure shot_id is the first column if present
+    if "shot_id" in df:
+        col = df.pop("shot_id")
+        df.insert(0, "shot_id", col)
+
     buffer = io.BytesIO()
     df.to_parquet(buffer)
     buffer.seek(0)


### PR DESCRIPTION
Quick PR to add aliases for endpoints that include the `.parquet` extension in the name. This is useful for resolving the file type.