### PR TITLE
Added originating scheme header to nginx config and uvicorn running

### DIFF
--- a/dev/docker/mast-api.Dockerfile
+++ b/dev/docker/mast-api.Dockerfile
@@ -12,4 +12,4 @@ COPY ./docs/built_docs/ /code/docs/built
 COPY ./docs/default_docs/ /code/docs/default
 
 
-ENTRYPOINT ["uvicorn", "src.api.main:app", "--host", "0.0.0.0", "--port", "80"]
+ENTRYPOINT ["uvicorn", "src.api.main:app", "--host", "0.0.0.0", "--port", "80", "--forward-allowed-ips","*"]

--- a/dev/docker/nginx.conf
+++ b/dev/docker/nginx.conf
@@ -32,6 +32,7 @@ server {
   #By defeault send requests to the documentation
   location / {
       proxy_pass  http://mast-api:5000/;
+      proxy_set_header X-Forwarded-Proto $scheme;
   }
 
 }


### PR DESCRIPTION
Added originating scheme header to nginx config and uvicorn running, hopefully this will allow the files returned by the API to be sent using the requesting protocol (I.e. http -> https, https -> https)