### PR TITLE
Align JSON-LD output with DCAT

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,8 @@ dependencies = [
     "tqdm>=4.66.5",
     "ujson>=5.10.0",
     "uvicorn>=0.32.0",
+    "rdflib>=7.0.0",
+    "rdflib-jsonld>=0.6.0"
 ]
 
 [project.urls]

--- a/src/api/create.py
+++ b/src/api/create.py
@@ -1,7 +1,6 @@
 import json
 import logging
 import math
-from os import path
 import sqlite3
 import uuid
 from enum import Enum
@@ -13,6 +12,8 @@ import numpy as np
 import pandas as pd
 import pyarrow.parquet as pq
 from psycopg2.extras import Json
+from rdflib import Graph, Literal, URIRef
+from rdflib.namespace import DCAT, DCTERMS, FOAF, RDF
 from sqlalchemy import MetaData, create_engine, text
 from sqlalchemy_utils.functions import create_database, database_exists, drop_database
 from sqlmodel import SQLModel
@@ -21,9 +22,6 @@ from tqdm import tqdm
 # Do not remove. Sqlalchemy needs this import to create tables
 from . import models, utils  # noqa: F401
 from .environment import DB_NAME, SQLALCHEMY_DATABASE_URL, SQLALCHEMY_DEBUG
-
-from rdflib import Graph, Namespace, URIRef, Literal
-from rdflib.namespace import DCAT, DCTERMS, FOAF, RDF, SKOS
 
 logging.basicConfig(level=logging.INFO)
 

--- a/src/api/create.py
+++ b/src/api/create.py
@@ -1,4 +1,3 @@
-import copy
 import logging
 import math
 import sqlite3
@@ -31,14 +30,10 @@ class Context(str, Enum):
     DCT = "http://purl.org/dc/terms/"
     FOAF = "http://xmlns.com/foaf/0.1/"
     SCHEMA = "https://schema.org"
-    DQV = "http://www.w3.org/ns/dqv#"
-    SDMX = "http://purl.org/linked-data/sdmx/2009/measure#"
 
 
 base_context = {
     "schema": Context.SCHEMA,
-    "dqv": Context.DQV,
-    "sdmx-measure": Context.SDMX,
     "dcat": Context.DCAT,
     "foaf": Context.FOAF,
     "dct": Context.DCT,
@@ -117,20 +112,6 @@ class DBCreationClient:
         df = pd.read_parquet(data_path / "shots.parquet")
         shot_ids = df.shot_id.unique()
 
-        signal_context = copy.deepcopy(base_context)
-        signal_context.update(
-            {
-                "title": "dct:title",
-                "uuid": "dct:identifier",
-                "url": "schema:url",
-                "name": "schema:name",
-                "version": "schema:version",
-                "description": "dct:description",
-                "quality": "qdv:QualityAnnotation",
-                "source": "dct:source",
-            }
-        )
-
         parquet_file = pq.ParquetFile(data_path / signals_file)
         batch_size = 100000
         n = math.ceil(parquet_file.scan_contents() / batch_size)
@@ -139,8 +120,6 @@ class DBCreationClient:
             df = df.reset_index(drop=True)
             df = df.drop_duplicates(["uuid"])
             df = df.loc[df.shot_id.isin(shot_ids)]
-
-            df["context"] = [Json(signal_context)] * len(df)
 
             # Convert to lists
             df["shape"] = df["shape"].map(
@@ -159,23 +138,10 @@ class DBCreationClient:
         df = pd.read_parquet(data_path / "shots.parquet")
         shot_ids = df.shot_id.unique()
 
-        source_context = copy.deepcopy(base_context)
-        source_context.update(
-            {
-                "title": "dct:title",
-                "uuid": "dct:identifier",
-                "url": "schema:url",
-                "name": "schema:name",
-                "description": "dct:description",
-                "quality": "qdv:QualityAnnotation",
-            }
-        )
-
         df = pd.read_parquet(data_path / sources_file)
         df = df.reset_index(drop=True)
         df = df.loc[df.shot_id.isin(shot_ids)]
         df["endpoint_url"] = endpoint_url
-        df["context"] = [Json(source_context)] * len(df)
 
         df = df.drop_duplicates(["uuid"])
         df["url"] = f"{url}/" + df.shot_id.astype(str) + ".zarr"
@@ -214,19 +180,9 @@ class DBCreationClient:
 
     def create_cpf_summary(self, data_path: Path):
         """Create the CPF summary table"""
-        cpf_context = copy.deepcopy(base_context)
-        cpf_context.update(
-            {
-                "index": "dct:identifier",
-                "name": "schema:name",
-                "description": "dct:description",
-            }
-        )
-
         path = data_path / "mast_cpf_columns.parquet"
         df = pd.read_parquet(str(path))
         df = df.reset_index(drop=True)
-        df["context"] = [Json(cpf_context)] * len(df)
         df = df.drop_duplicates(subset=["name"])
         df["name"] = df["name"].apply(
             lambda x: models.ShotModel.__fields__.get("cpf_" + x.lower()).alias
@@ -243,14 +199,8 @@ class DBCreationClient:
         ids = shot_metadata["scenario_id"].unique()
         scenarios = shot_metadata["scenario"].unique()
 
-        scenario_context = copy.deepcopy(base_context)
-        scenario_context.update(
-            {"title": "dct:title", "id": "dct:identifier", "name": "schema:name"}
-        )
-
         data = pd.DataFrame(dict(id=ids, name=scenarios)).set_index("id")
         data = data.dropna()
-        data["context"] = [Json(scenario_context)] * len(data)
         data.to_sql("scenarios", self.uri, if_exists="append")
 
     def create_shots(
@@ -266,16 +216,6 @@ class DBCreationClient:
         df = pd.read_parquet(data_path / sources_file)
         shot_ids = df.shot_id.unique()
 
-        shot_context = copy.deepcopy(base_context)
-        shot_context.update(
-            {
-                "title": "dct:title",
-                "uuid": "dct:identifier",
-                "url": "schema:url",
-                "timestamp": "dct:date",
-            }
-        )
-
         shot_file_name = data_path / "shots.parquet"
         shot_metadata = pd.read_parquet(shot_file_name)
         shot_metadata = shot_metadata.loc[shot_metadata.shot_id.isin(shot_ids)]
@@ -287,7 +227,6 @@ class DBCreationClient:
             lambda x: "MAST" if x <= LAST_MAST_SHOT else "MAST-U"
         )
         shot_metadata = shot_metadata.drop(["scenario_id", "reference_id"], axis=1)
-        shot_metadata["context"] = [Json(shot_context)] * len(shot_metadata)
         shot_metadata["uuid"] = shot_metadata.index.map(get_dataset_uuid)
         shot_metadata["url"] = f"{url}/" + shot_metadata.index.astype(str) + ".zarr"
         shot_metadata["endpoint_url"] = endpoint_url

--- a/src/api/create.py
+++ b/src/api/create.py
@@ -1,5 +1,7 @@
+import json
 import logging
 import math
+from os import path
 import sqlite3
 import uuid
 from enum import Enum
@@ -17,27 +19,15 @@ from sqlmodel import SQLModel
 from tqdm import tqdm
 
 # Do not remove. Sqlalchemy needs this import to create tables
-from . import models  # noqa: F401
+from . import models, utils  # noqa: F401
 from .environment import DB_NAME, SQLALCHEMY_DATABASE_URL, SQLALCHEMY_DEBUG
+
+from rdflib import Graph, Namespace, URIRef, Literal
+from rdflib.namespace import DCAT, DCTERMS, FOAF, RDF, SKOS
 
 logging.basicConfig(level=logging.INFO)
 
 LAST_MAST_SHOT = 30473  # This is the last MAST shot before MAST-U
-
-
-class Context(str, Enum):
-    DCAT = "http://www.w3.org/ns/dcat#"
-    DCT = "http://purl.org/dc/terms/"
-    FOAF = "http://xmlns.com/foaf/0.1/"
-    SCHEMA = "https://schema.org"
-
-
-base_context = {
-    "schema": Context.SCHEMA,
-    "dcat": Context.DCAT,
-    "foaf": Context.FOAF,
-    "dct": Context.DCT,
-}
 
 
 class URLType(Enum):
@@ -255,52 +245,62 @@ class DBCreationClient:
         shot_metadata.to_sql(table_name, self.uri, if_exists="append")
 
     def create_serve_dataset(self):
-        data = {
-            "servesdataset": [
-                [
-                    "host/json/shots",
-                    "host/json/shots/aggregate",
-                    "host/json/shots/shot_id",
-                    "host/json/shots/shot_id/signal",
-                    "host/json/signals",
-                    "host/json/signals/uuid",
-                    "host/json/signals/uuid/shots",
-                    "host/json/scenario",
-                    "host/json/source",
-                    "host/json/source/aggregate",
-                    "host/json/source/name",
-                    "host/json/cpfsummary",
-                ]
-            ],
-            "theme": [
-                [
-                    "host/json/shots",
-                    "host/json/signal",
-                    "host/json/source",
-                    "host/json/scenario",
-                    "host/json/cpfsummary",
-                ]
-            ],
-            "type": ["dcat:DataService"],
-            "id": ["host/json/data-service"],
-            "title": ["FAIR MAST Data Service"],
-            "description": [
-                "UKAEA Data Service providing access to the FAIR MAST dataset. \
-                          This includes signal, source, shots and other datasets."
-            ],
-            "endpointurl": ["host"],
+        g = Graph()
+        g = utils.bind_base_namespaces(g)
+
+        service_uri = URIRef("https://localhost:8081/json/dataservice")
+
+        g.add((service_uri, RDF.type, DCAT.DataService))
+        g.add((service_uri, DCTERMS.title, Literal("FAIR MAST Data Service")))
+        g.add((service_uri, DCTERMS.description, Literal("UKAEA Data Service providing access to the FAIR MAST dataset. This includes signal, source, shots and other datasets.")))
+        g.add((service_uri, DCAT.endpointURL, URIRef("https://localhost:8081")))
+        g.add((service_uri, DCAT.endpointDescription, URIRef("https://localhost:8081/redoc")))
+        g.add((service_uri, DCAT.landingPage, URIRef("https://localhost:8081/redoc")))
+
+        service_endpoints = [
+            "host/json/shots", 
+            "host/json/shots/aggregate", 
+            "host/json/shots/shot_id",
+            "host/json/shots/shot_id/signal", 
+            "host/json/signals", 
+            "host/json/signals/uuid",
+            "host/json/signals/uuid/shots", 
+            "host/json/scenario", 
+            "host/json/source",
+            "host/json/source/aggregate", 
+            "host/json/source/name", 
+            "host/json/cpfsummary",
+        ]
+        for service_endpoint in service_endpoints:
+            g.add((service_uri, DCAT.servesDataset, Literal(service_endpoint)))
+
+        # Publisher as RDF resources
+        publisher_uri = URIRef("https://ror.org/0361bwx64")
+        g.add((service_uri, DCTERMS.publisher, publisher_uri))
+        g.add((publisher_uri, RDF.type, FOAF.Organization))
+        g.add((publisher_uri, FOAF.name, Literal("UKAEA")))
+        g.add((publisher_uri, FOAF.homepage, URIRef("https://www.ukaea.org/")))
+
+        dynamic_context = utils.get_context_for_graph(g)
+
+        # 3. Serialize using the new, minimal context
+        jsonld_str = g.serialize(format="json-ld", context=dynamic_context)
+        jsonld_dict = json.loads(jsonld_str)
+            
+        row = {
+            "context": Json(dynamic_context),  # Use the context we just built
+            "jsonld": Json(jsonld_dict),
+            "type": DCAT.DataService,
+            "id": str(service_uri),
+            "title": g.value(service_uri, DCTERMS.title),
+            "description": g.value(service_uri, DCTERMS.description),
+            "publisher": Json({"@id": str(publisher_uri)}),
+            "endpointurl": str(g.value(service_uri, DCAT.endpointURL)),
+            "servesdataset": service_endpoints,
+            "theme": None, ##here we will add FUEL terms
         }
-        publisher = {
-            "dct__publisher": {
-                "type_": "foaf:Organization",
-                "foaf:name": "UKAEA",
-                "foaf:homepage": "http://ukaea.uk",
-            }
-        }
-        df = pd.DataFrame(data, index=[0])
-        df["publisher"] = Json(publisher)
-        df["id"] = "host/json/data-service"
-        df["context"] = Json(dict(list(base_context.items())[-3:]))
+
+        df = pd.DataFrame([row])        
         df.to_sql("dataservice", self.uri, if_exists="append", index=False)
 
 

--- a/src/api/environment.py
+++ b/src/api/environment.py
@@ -9,3 +9,9 @@ DB_NAME = "mast_db"
 SQLALCHEMY_DATABASE_URL = f"postgresql://{pg_user}:{pg_password}@{host}:5432/{DB_NAME}"
 # Echo SQL statements
 SQLALCHEMY_DEBUG = os.environ.get("SQLALCHEMY_DEBUG", False)
+
+#data license
+LICENSE_URL = os.environ.get(
+    "LICENSE_URL",
+    "https://creativecommons.org/licenses/by-sa/4.0/",
+)

--- a/src/api/environment.py
+++ b/src/api/environment.py
@@ -10,6 +10,10 @@ SQLALCHEMY_DATABASE_URL = f"postgresql://{pg_user}:{pg_password}@{host}:5432/{DB
 # Echo SQL statements
 SQLALCHEMY_DEBUG = os.environ.get("SQLALCHEMY_DEBUG", False)
 
+SITE_URL = "http://localhost:8081"
+if "VIRTUAL_HOST" in os.environ:
+    SITE_URL = f"https://{os.environ.get('VIRTUAL_HOST')}"
+
 #data license
 LICENSE_URL = os.environ.get(
     "LICENSE_URL",

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -26,10 +26,26 @@ from strawberry.types import ExecutionResult
 
 from . import crud, graphql, models, utils
 from .database import get_db
-from .environment import LICENSE_URL
+from .environment import LICENSE_URL, SITE_URL
 
 templates = Jinja2Templates(directory="src/api/templates")
 
+_SKIP_KEYS = {"context_", "type_", "@context", "@type", "@id"}
+
+_DATASET_TERMS = {
+    "uuid": "dct:identifier",
+    "timestamp": "dct:date",
+    "description": "dct:description",
+    "source": "dct:source",
+    "title": "dct:title",
+    "name": "schema:name",
+    "version": "schema:version",
+}
+
+_DEFINED_TERM_TERMS = {
+    "name": "schema:name",
+    "description": "dct:description",
+}
 
 class JSONLDGraphQL(GraphQL):
     async def process_result(
@@ -66,11 +82,6 @@ class JSONLDGraphQL(GraphQL):
 graphql_app = JSONLDGraphQL(
     graphql.schema,
 )
-
-
-SITE_URL = "http://localhost:8081"
-if "VIRTUAL_HOST" in os.environ:
-    SITE_URL = f"https://{os.environ.get('VIRTUAL_HOST')}"
 
 DEFAULT_PER_PAGE = 100
 
@@ -183,49 +194,35 @@ class AggregateQueryParams:
         self.per_page = per_page
 
 
-def _rewrite(value):
-    """Translate SQLModel-alias keys to their JSON-LD form, recursively
-    through any dict / list tree."""
-    if isinstance(value, dict):
-        out: dict = {}
-        for k, v in value.items():
-            if k.startswith("@"):
-                pass
-            elif k.endswith("_") and "__" not in k:
-                k = f"@{k[:-1]}"
-            elif "__" in k:
-                k = k.replace("__", ":", 1)
-            out[k] = _rewrite(v)
-        return out
-    if isinstance(value, list):
-        return [_rewrite(v) for v in value]
-    return value
-
-
-def _context_for(node) -> dict:
-    """Minimal ``@context`` for a rendered node, drawn from the same
-    prefix bindings ``create.DBCreationClient.create_serve_dataset``
-    uses (``utils.bind_base_namespaces``). A prefix is included when it
-    appears in a CURIE key or in a string value like ``dcat:Dataset``."""
+def _context_for(node, terms: Optional[dict] = None) -> dict:
+    """Minimal ``@context`` for a rendered node"""
     g = Graph()
     utils.bind_base_namespaces(g)
     prefixes = {p: str(n) for p, n in g.namespace_manager.namespaces()}
-    used: set = set()
+    used_prefixes: set = set()
+    used_terms: dict = {}
 
     def walk(v):
         if isinstance(v, dict):
             for k, val in v.items():
                 if ":" in k and not k.startswith("@") and k.split(":", 1)[0] in prefixes:
-                    used.add(k.split(":", 1)[0])
+                    used_prefixes.add(k.split(":", 1)[0])
+                if terms and k in terms:
+                    used_terms[k] = terms[k]
+                    prefix = terms[k].split(":", 1)[0]
+                    if prefix in prefixes:
+                        used_prefixes.add(prefix)
                 walk(val)
         elif isinstance(v, list):
             for x in v:
                 walk(x)
         elif isinstance(v, str) and ":" in v and v.split(":", 1)[0] in prefixes:
-            used.add(v.split(":", 1)[0])
+            used_prefixes.add(v.split(":", 1)[0])
 
     walk(node)
-    return {p: prefixes[p] for p in sorted(used)}
+    context = {p: prefixes[p] for p in sorted(used_prefixes)}
+    context.update(used_terms)
+    return context
 
 
 def _distribution(item) -> Optional[dict]:
@@ -244,27 +241,56 @@ def _distribution(item) -> Optional[dict]:
     }
 
 
-def _node(item, *, at_type: str, with_distribution: bool = False) -> dict:
-    """Render a record dict as a JSON-LD node of the given ``@type``.
-    The record's keys are already SQLModel aliases; ``_rewrite`` handles
-    the translation, and the surrounding ``@type`` / ``@context`` set
-    here take precedence over any defaults the model supplied."""
-    distribution = _distribution(item) if with_distribution else None
+def _dataset_node(item) -> dict:
+    """Render a record as a ``dcat:Dataset`` body. Column names stay
+    as-is (``description``, ``uuid``, ``shot_id``, ...); the response
+    class's ``@context`` maps the ones with RDF semantics to their
+    predicates."""
+    distribution = _distribution(item)
     if distribution is not None:
         item = {k: v for k, v in item.items() if k not in ("url", "endpoint_url")}
-    body = _rewrite(item)
-    body.pop("@context", None)
-    body.pop("@type", None)
-    out: dict = {"@type": at_type, **body}
+    node: dict = {"@type": "dcat:Dataset"}
+    for k, v in item.items():
+        if k in _SKIP_KEYS:
+            continue
+        node[k] = v
     if distribution is not None:
-        out["dcat:distribution"] = distribution
-    return out
+        node["dcat:distribution"] = distribution
+    return node
 
 
-def _render(body: dict, wrapper: Optional[dict] = None) -> bytes:
-    """Prepend an ``@context`` derived from CURIEs in ``body``, fold in
-    any wrapper keys (e.g. pagination metadata), and dump to JSON."""
-    result = {"@context": _context_for(body), **body}
+def _defined_term_node(item) -> dict:
+    node: dict = {"@type": "schema:DefinedTerm"}
+    for k, v in item.items():
+        if k in _SKIP_KEYS:
+            continue
+        node[k] = v
+    return node
+
+
+def _rewrite_key(key: str) -> str:
+    if key.startswith("@"):
+        return key
+    if key.endswith("_") and "__" not in key:
+        return f"@{key[:-1]}"
+    if "__" in key:
+        return key.replace("__", ":", 1)
+    return key
+
+
+def _rewrite(value):
+    """Apply ``_rewrite_key`` recursively through a dict / list tree."""
+    if isinstance(value, dict):
+        return {_rewrite_key(k): _rewrite(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_rewrite(v) for v in value]
+    return value
+
+
+def _render(body: dict, terms: Optional[dict] = None, wrapper: Optional[dict] = None) -> bytes:
+    """Prepend a @context fold in any wrapper keys (e.g. pagination metadata), and
+    dump to JSON."""
+    result = {"@context": _context_for(body, terms), **body}
     if wrapper:
         result.update(wrapper)
     return json.dumps(result, default=str).encode()
@@ -276,11 +302,11 @@ class DatasetResponse(JSONResponse):
     media_type = "application/json"
 
     def render(self, content) -> bytes:
-        return _render(_node(content, at_type="dcat:Dataset", with_distribution=True))
+        return _render(_dataset_node(content), _DATASET_TERMS)
 
 
 class CatalogResponse(JSONResponse):
-    """A paginated listing as a ``dcat:Catalog`` of datasets."""
+    """A paginated listing as a dcat:Catalog of datasets"""
 
     media_type = "application/json"
 
@@ -289,17 +315,14 @@ class CatalogResponse(JSONResponse):
         wrapper = {k: v for k, v in content.items() if k != "items"}
         catalog = {
             "@type": "dcat:Catalog",
-            "dcat:dataset": [
-                _node(it, at_type="dcat:Dataset", with_distribution=True)
-                for it in items
-            ],
+            "items": [_dataset_node(item) for item in items],
         }
-        return _render(catalog, wrapper)
+        terms = {**_DATASET_TERMS, "items": "dcat:dataset"}
+        return _render(catalog, terms, wrapper)
 
 
 class DefinedTermSetResponse(JSONResponse):
-    """A paginated glossary as a ``schema:DefinedTermSet`` of
-    ``schema:DefinedTerm`` entries."""
+    """A paginated glossary as a schema:DefinedTermSet of schema:DefinedTerm entries."""
 
     media_type = "application/json"
 
@@ -308,25 +331,14 @@ class DefinedTermSetResponse(JSONResponse):
         wrapper = {k: v for k, v in content.items() if k != "items"}
         term_set = {
             "@type": "schema:DefinedTermSet",
-            "schema:hasDefinedTerm": [
-                _node(it, at_type="schema:DefinedTerm") for it in items
-            ],
+            "items": [_defined_term_node(item) for item in items],
         }
-        return _render(term_set, wrapper)
+        terms = {**_DEFINED_TERM_TERMS, "items": "schema:hasDefinedTerm"}
+        return _render(term_set, terms, wrapper)
 
 
 class DataServiceResponse(JSONResponse):
-    """The data service description as a ``dcat:DataService``.
-
-    ``DataService`` already carries its RDF predicates as SQLModel
-    aliases (``dct__title``, ``dcat__endpointURL``, ``dcat__servesDataset``,
-    ...), and ``create.create_serve_dataset`` stores a full ``@context``
-    on the row, so this renderer is a single call to ``_rewrite``. Once
-    that function lands its three open TODOs (real ``dcat:servesDataset``
-    references, a deployment-aware service URI, further validation),
-    this class is the natural place to extend the output -- e.g. by
-    inlining the referenced ``dcat:Dataset`` summaries rather than
-    carrying bare URIs."""
+    """The data service description as a dcat:DataService"""
 
     media_type = "application/json"
 

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -211,6 +211,7 @@ class CustomJSONResponse(JSONResponse):
         "type":   "@type",
         "name":        "schema:name",
         "description": "dct:description",
+        "items":       "schema:hasDefinedTerm",
     }
 
     _CLASS_LABEL_TITLES = {
@@ -231,9 +232,9 @@ class CustomJSONResponse(JSONResponse):
                 merged["items"] = [self._to_dataset(it) for it in items]
                 merged["@context"] = self._CONTEXT
             elif items and self._is_defined_term(items[0]):
+                merged["@type"] = "schema:DefinedTermSet"
                 merged["items"] = [self._to_defined_term(it) for it in items]
                 merged["@context"] = self._DEFINED_TERM_CONTEXT
-                merged.pop("@type", None)
         elif isinstance(merged, dict) and self._is_dataset(merged):
             # Single-record endpoint, e.g. /json/shots/{shot_id}.
             merged = self._to_dataset(merged)

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -2,7 +2,6 @@ import datetime
 import io
 import json
 import os
-import re
 import uuid
 from pathlib import Path
 from typing import List, Optional
@@ -19,13 +18,15 @@ from fastapi.templating import Jinja2Templates
 from fastapi_pagination import add_pagination
 from fastapi_pagination.cursor import CursorPage
 from fastapi_pagination.ext.sqlalchemy import paginate
+from rdflib import Graph
 from sqlalchemy.orm import Session
 from strawberry.asgi import GraphQL
 from strawberry.http import GraphQLHTTPResponse
 from strawberry.types import ExecutionResult
 
-from . import crud, graphql, models
+from . import crud, graphql, models, utils
 from .database import get_db
+from .environment import LICENSE_URL
 
 templates = Jinja2Templates(directory="src/api/templates")
 
@@ -182,150 +183,155 @@ class AggregateQueryParams:
         self.per_page = per_page
 
 
-class CustomJSONResponse(JSONResponse):
-    """
-    serializes the result of a database query (a dictionary) into a JSON-readable format
-    """
+def _rewrite(value):
+    """Translate SQLModel-alias keys to their JSON-LD form, recursively
+    through any dict / list tree."""
+    if isinstance(value, dict):
+        out: dict = {}
+        for k, v in value.items():
+            if k.startswith("@"):
+                pass
+            elif k.endswith("_") and "__" not in k:
+                k = f"@{k[:-1]}"
+            elif "__" in k:
+                k = k.replace("__", ":", 1)
+            out[k] = _rewrite(v)
+        return out
+    if isinstance(value, list):
+        return [_rewrite(v) for v in value]
+    return value
+
+
+def _context_for(node) -> dict:
+    """Minimal ``@context`` for a rendered node, drawn from the same
+    prefix bindings ``create.DBCreationClient.create_serve_dataset``
+    uses (``utils.bind_base_namespaces``). A prefix is included when it
+    appears in a CURIE key or in a string value like ``dcat:Dataset``."""
+    g = Graph()
+    utils.bind_base_namespaces(g)
+    prefixes = {p: str(n) for p, n in g.namespace_manager.namespaces()}
+    used: set = set()
+
+    def walk(v):
+        if isinstance(v, dict):
+            for k, val in v.items():
+                if ":" in k and not k.startswith("@") and k.split(":", 1)[0] in prefixes:
+                    used.add(k.split(":", 1)[0])
+                walk(val)
+        elif isinstance(v, list):
+            for x in v:
+                walk(x)
+        elif isinstance(v, str) and ":" in v and v.split(":", 1)[0] in prefixes:
+            used.add(v.split(":", 1)[0])
+
+    walk(node)
+    return {p: prefixes[p] for p in sorted(used)}
+
+
+def _distribution(item) -> Optional[dict]:
+    """Build a ``dcat:Distribution`` from ``url`` / ``endpoint_url`` if
+    the record carries an ``s3://`` URL with an HTTP endpoint."""
+    s3_url = item.get("url")
+    endpoint = item.get("endpoint_url")
+    if not (isinstance(s3_url, str) and s3_url.startswith("s3://") and endpoint):
+        return None
+    return {
+        "@type": "dcat:Distribution",
+        "dcat:accessURL": SITE_URL,
+        "dcat:downloadURL": f"{endpoint.rstrip('/')}/{s3_url[len('s3://'):]}",
+        "dcat:mediaType": "application/zarr",
+        "dct:license": LICENSE_URL,
+    }
+
+
+def _node(item, *, at_type: str, with_distribution: bool = False) -> dict:
+    """Render a record dict as a JSON-LD node of the given ``@type``.
+    The record's keys are already SQLModel aliases; ``_rewrite`` handles
+    the translation, and the surrounding ``@type`` / ``@context`` set
+    here take precedence over any defaults the model supplied."""
+    distribution = _distribution(item) if with_distribution else None
+    if distribution is not None:
+        item = {k: v for k, v in item.items() if k not in ("url", "endpoint_url")}
+    body = _rewrite(item)
+    body.pop("@context", None)
+    body.pop("@type", None)
+    out: dict = {"@type": at_type, **body}
+    if distribution is not None:
+        out["dcat:distribution"] = distribution
+    return out
+
+
+def _render(body: dict, wrapper: Optional[dict] = None) -> bytes:
+    """Prepend an ``@context`` derived from CURIEs in ``body``, fold in
+    any wrapper keys (e.g. pagination metadata), and dump to JSON."""
+    result = {"@context": _context_for(body), **body}
+    if wrapper:
+        result.update(wrapper)
+    return json.dumps(result, default=str).encode()
+
+
+class DatasetResponse(JSONResponse):
+    """A single ``dcat:Dataset`` record."""
 
     media_type = "application/json"
 
-    _CONTEXT = {
-        "dcat":   "http://www.w3.org/ns/dcat#",
-        "dct":    "http://purl.org/dc/terms/",
-        "foaf":   "http://xmlns.com/foaf/0.1/",
-        "schema": "https://schema.org/",
-        "id":     "@id",
-        "type":   "@type",
-        "items":  "dcat:dataset",
-        "uuid":        "dct:identifier",
-        "description": "dct:description",
-        "name":        "schema:name",
-        "version":     "schema:version",
-        "source":      "dct:source",
-        "timestamp":   "dct:date",
-        "distribution": "dcat:distribution",
-        "accessURL":    "dcat:accessURL",
-        "downloadURL":  "dcat:downloadURL",
-        "mediaType":    "dcat:mediaType",
-    }
+    def render(self, content) -> bytes:
+        return _render(_node(content, at_type="dcat:Dataset", with_distribution=True))
 
-    _DEFINED_TERM_CONTEXT = {
-        "dct":    "http://purl.org/dc/terms/",
-        "schema": "https://schema.org/",
-        "type":   "@type",
-        "name":        "schema:name",
-        "description": "dct:description",
-        "items":       "schema:hasDefinedTerm",
-    }
 
-    _CLASS_LABEL_TITLES = {
-        "Shot Dataset", "Signal Dataset", "Source Dataset",
-        "CPF Summary Item", "Tokamak Scenario",
-    }
+class CatalogResponse(JSONResponse):
+    """A paginated listing as a ``dcat:Catalog`` of datasets."""
+
+    media_type = "application/json"
 
     def render(self, content) -> bytes:
-        content = self.convert_to_jsonld_terms(content)
-        extracted_dict = {}
-        edited_content = self.extract_meta_key(content, extracted_dict)
-        merged = {**extracted_dict, **edited_content}
+        items = content.get("items", [])
+        wrapper = {k: v for k, v in content.items() if k != "items"}
+        catalog = {
+            "@type": "dcat:Catalog",
+            "dcat:dataset": [
+                _node(it, at_type="dcat:Dataset", with_distribution=True)
+                for it in items
+            ],
+        }
+        return _render(catalog, wrapper)
 
-        if isinstance(merged, dict) and isinstance(merged.get("items"), list):
-            items = merged["items"]
-            if items and self._is_dataset(items[0]):
-                merged["@type"] = "dcat:Catalog"
-                merged["items"] = [self._to_dataset(it) for it in items]
-                merged["@context"] = self._CONTEXT
-            elif items and self._is_defined_term(items[0]):
-                merged["@type"] = "schema:DefinedTermSet"
-                merged["items"] = [self._to_defined_term(it) for it in items]
-                merged["@context"] = self._DEFINED_TERM_CONTEXT
-        elif isinstance(merged, dict) and self._is_dataset(merged):
-            # Single-record endpoint, e.g. /json/shots/{shot_id}.
-            merged = self._to_dataset(merged)
-            merged["@context"] = self._CONTEXT
 
-        return json.dumps(merged, default=str).encode()
+class DefinedTermSetResponse(JSONResponse):
+    """A paginated glossary as a ``schema:DefinedTermSet`` of
+    ``schema:DefinedTerm`` entries."""
 
-    @staticmethod
-    def _is_dataset(item):
-        return isinstance(item, dict) and ("shot_id" in item or "uuid" in item)
+    media_type = "application/json"
 
-    @staticmethod
-    def _is_defined_term(item):
-        if not isinstance(item, dict):
-            return False
-        if "shot_id" in item or "uuid" in item:
-            return False
-        return "index" in item or "id" in item
+    def render(self, content) -> bytes:
+        items = content.get("items", [])
+        wrapper = {k: v for k, v in content.items() if k != "items"}
+        term_set = {
+            "@type": "schema:DefinedTermSet",
+            "schema:hasDefinedTerm": [
+                _node(it, at_type="schema:DefinedTerm") for it in items
+            ],
+        }
+        return _render(term_set, wrapper)
 
-    def _strip_class_label_title(self, item):
-        if item.get("title") in self._CLASS_LABEL_TITLES:
-            item.pop("title", None)
 
-    def _to_dataset(self, item):
-        if not isinstance(item, dict):
-            return item
-        self._strip_class_label_title(item)
-        s3_url = item.pop("url", None)
-        endpoint = item.pop("endpoint_url", None)
-        if isinstance(s3_url, str) and s3_url.startswith("s3://") and endpoint:
-            item["distribution"] = [{
-                "@type": "dcat:Distribution",
-                "accessURL": SITE_URL,
-                "downloadURL": f"{endpoint.rstrip('/')}/{s3_url[len('s3://'):]}",
-                "mediaType": "application/zarr",
-            }]
-        item["@type"] = "dcat:Dataset"
-        return item
+class DataServiceResponse(JSONResponse):
+    """The data service description as a ``dcat:DataService``.
 
-    def _to_defined_term(self, item):
-        """Type a row as schema:DefinedTerm and strip its class-label title."""
-        if not isinstance(item, dict):
-            return item
-        self._strip_class_label_title(item)
-        item["@type"] = "schema:DefinedTerm"
-        return item
+    ``DataService`` already carries its RDF predicates as SQLModel
+    aliases (``dct__title``, ``dcat__endpointURL``, ``dcat__servesDataset``,
+    ...), and ``create.create_serve_dataset`` stores a full ``@context``
+    on the row, so this renderer is a single call to ``_rewrite``. Once
+    that function lands its three open TODOs (real ``dcat:servesDataset``
+    references, a deployment-aware service URI, further validation),
+    this class is the natural place to extend the output -- e.g. by
+    inlining the referenced ``dcat:Dataset`` summaries rather than
+    carrying bare URIs."""
 
-    def convert_to_jsonld_terms(self, items):
-        """
-        Replaces '__' with ':', and [A-Za-z_] with [@A-Za-z] in the mapping of terms (column names) to
-        their URIs to ensure the output data conforms with JSON-readable format
-        """
-        if not isinstance(items, dict):
-            return items
-        for key, val in list(items.items()):
-            # Recursive key modification if value is a dictionary or list object
-            if isinstance(val, list):
-                items[key] = [self.convert_to_jsonld_terms(item) for item in val]
-            if isinstance(val, dict):
-                items[key] = self.convert_to_jsonld_terms(val)
+    media_type = "application/json"
 
-            if key.endswith("_"):
-                items[f"@{key[:-1]}"] = items.pop(key)
-            elif "__" in str(key):
-                items[re.sub("__", ":", key)] = items.pop(key)
-        return items
-
-    def extract_meta_key(self, content, extracted_dict):
-        """
-        Extract keys and values of @context and @type from the dictionary to
-        return them at the top of the dictionary as one entity for the whole dictionary,
-        rather than each for each item since they contain the same key and values
-        """
-        target_keys = ["@context", "@type", "dct:title"]
-        for k, v in list(content.items()):
-            if k in target_keys:
-                extracted_dict[k] = v
-                content.pop(k, None)
-            elif isinstance(v, dict):
-                # recursive edit_dict call for nested dict
-                self.extract_meta_key(v, extracted_dict)
-            elif isinstance(v, list):
-                for item in v:
-                    if isinstance(item, dict):
-                        self.extract_meta_key(item, extracted_dict)
-        # return popped content
-        return content
+    def render(self, content) -> bytes:
+        return json.dumps(_rewrite(content), default=str).encode()
 
 
 def apply_pagination(
@@ -375,7 +381,6 @@ def query_aggregate(
 @app.get(
     "/json",
     description="Root of JSON API - shows available endpoints.",
-    response_class=CustomJSONResponse,
 )
 def json_root():
     return {
@@ -394,7 +399,7 @@ def json_root():
     "/json/shots",
     description="Get information about experimental shots",
     response_model=CursorPage[models.ShotModel],
-    response_class=CustomJSONResponse,
+    response_class=CatalogResponse,
 )
 def get_shots(db: Session = Depends(get_db), params: QueryParams = Depends()):
     if params.sort is None:
@@ -421,7 +426,7 @@ def get_shots_aggregate(
     "/json/shots/{shot_id}",
     description="Get information about a single experimental shot",
     response_model=models.ShotModel,
-    response_class=CustomJSONResponse,
+    response_class=DatasetResponse,
 )
 def get_shot(db: Session = Depends(get_db), shot_id: int = None):
     shot = crud.get_shot(shot_id)
@@ -432,7 +437,7 @@ def get_shot(db: Session = Depends(get_db), shot_id: int = None):
 @app.get(
     "/json/dataservice",
     description="Get information about a the data service this application offers",
-    response_class=CustomJSONResponse,
+    response_class=DataServiceResponse,
 )
 def get_dataservice(db: Session = Depends(get_db)):
     dataservices = crud.get_dataservices(db)
@@ -443,7 +448,7 @@ def get_dataservice(db: Session = Depends(get_db)):
     "/json/shots/{shot_id}/signals",
     description="Get information all signals for a single experimental shot",
     response_model=CursorPage[models.SignalModel],
-    response_class=CustomJSONResponse,
+    response_class=CatalogResponse,
 )
 def get_signals_for_shot(
     db: Session = Depends(get_db),
@@ -468,7 +473,7 @@ def get_signals_for_shot(
     "/json/level2/shots",
     description="Get information about experimental shots",
     response_model=CursorPage[models.Level2ShotModel],
-    response_class=CustomJSONResponse,
+    response_class=CatalogResponse,
 )
 def get_level2_shots(
     db: Session = Depends(get_db),
@@ -498,7 +503,7 @@ def get_level2_shots_aggregate(
     "/json/level2/shots/{shot_id}",
     description="Get information about a single experimental shot",
     response_model=models.Level2ShotModel,
-    response_class=CustomJSONResponse,
+    response_class=DatasetResponse,
 )
 def get_level2_shot(db: Session = Depends(get_db), shot_id: int = None):
     shot = crud.get_level2_shot(shot_id)
@@ -510,7 +515,7 @@ def get_level2_shot(db: Session = Depends(get_db), shot_id: int = None):
     "/json/level2/shots/{shot_id}/signals",
     description="Get information all signals for a single experimental shot",
     response_model=models.Level2SignalModel,
-    response_class=CustomJSONResponse,
+    response_class=CatalogResponse,
 )
 def get_signals_for_level2_shot(
     db: Session = Depends(get_db),
@@ -535,7 +540,7 @@ def get_signals_for_level2_shot(
     "/json/signals",
     description="Get information about specific signals.",
     response_model=CursorPage[models.SignalModel],
-    response_class=CustomJSONResponse,
+    response_class=CatalogResponse,
 )
 def get_signals(db: Session = Depends(get_db), params: QueryParams = Depends()):
     if params.sort is None:
@@ -563,7 +568,7 @@ def get_signals_aggregate(
     description="Get information about a single signal",
     response_model_exclude_unset=True,
     response_model=models.SignalModel,
-    response_class=CustomJSONResponse,
+    response_class=DatasetResponse,
 )
 def get_signal(db: Session = Depends(get_db), uuid_: uuid.UUID = None):
     signal = crud.get_signal(uuid_)
@@ -577,7 +582,7 @@ def get_signal(db: Session = Depends(get_db), uuid_: uuid.UUID = None):
     description="Get information about the shot for a single signal",
     response_model_exclude_unset=True,
     response_model=models.ShotModel,
-    response_class=CustomJSONResponse,
+    response_class=DatasetResponse,
 )
 def get_shot_for_signal(
     db: Session = Depends(get_db), uuid_: uuid.UUID = None
@@ -593,7 +598,7 @@ def get_shot_for_signal(
     "/json/level2/signals",
     description="Get information about specific signals.",
     response_model=CursorPage[models.Level2SignalModel],
-    response_class=CustomJSONResponse,
+    response_class=CatalogResponse,
 )
 def get_level2_signals(db: Session = Depends(get_db), params: QueryParams = Depends()):
     if params.sort is None:
@@ -621,7 +626,7 @@ def get_level2_signals_aggregate(
     description="Get information about a single signal",
     response_model_exclude_unset=True,
     response_model=models.Level2SignalModel,
-    response_class=CustomJSONResponse,
+    response_class=DatasetResponse,
 )
 def get_level2_signal(db: Session = Depends(get_db), uuid_: uuid.UUID = None):
     signal = crud.get_level2_signal(uuid_)
@@ -634,7 +639,7 @@ def get_level2_signal(db: Session = Depends(get_db), uuid_: uuid.UUID = None):
     description="Get information about the shot for a single signal",
     response_model_exclude_unset=True,
     response_model=models.Level2ShotModel,
-    response_class=CustomJSONResponse,
+    response_class=DatasetResponse,
 )
 def get_shot_for_level2_signal(db: Session = Depends(get_db), uuid_: uuid.UUID = None):
     signal = crud.get_level2_signal(uuid_)
@@ -648,7 +653,7 @@ def get_shot_for_level2_signal(db: Session = Depends(get_db), uuid_: uuid.UUID =
     "/json/cpf_summary",
     description="Get descriptions of CPF summary variables.",
     response_model=CursorPage[models.CPFSummaryModel],
-    response_class=CustomJSONResponse,
+    response_class=DefinedTermSetResponse,
 )
 def get_cpf_summary(db: Session = Depends(get_db), params: QueryParams = Depends()):
     if params.sort is None:
@@ -664,7 +669,7 @@ def get_cpf_summary(db: Session = Depends(get_db), params: QueryParams = Depends
     "/json/scenarios",
     description="Get information on different scenarios.",
     response_model=CursorPage[models.ScenarioModel],
-    response_class=CustomJSONResponse,
+    response_class=DefinedTermSetResponse,
 )
 def get_scenarios(db: Session = Depends(get_db), params: QueryParams = Depends()):
     if params.sort is None:
@@ -680,7 +685,7 @@ def get_scenarios(db: Session = Depends(get_db), params: QueryParams = Depends()
     "/json/sources",
     description="Get information on different sources.",
     response_model=CursorPage[models.SourceModel],
-    response_class=CustomJSONResponse,
+    response_class=CatalogResponse,
 )
 def get_sources(db: Session = Depends(get_db), params: QueryParams = Depends()):
     if params.sort is None:
@@ -695,7 +700,6 @@ def get_sources(db: Session = Depends(get_db), params: QueryParams = Depends()):
 @app.get(
     "/json/sources/aggregate",
     response_model=models.SourceModel,
-    response_class=CustomJSONResponse,
 )
 def get_sources_aggregate(
     request: Request,
@@ -711,7 +715,7 @@ def get_sources_aggregate(
     "/json/sources/{name}",
     description="Get information about a single signal",
     response_model=models.SourceModel,
-    response_class=CustomJSONResponse,
+    response_class=DatasetResponse,
 )
 def get_single_source(db: Session = Depends(get_db), name: str = None):
     source = crud.get_source(db, name)
@@ -723,7 +727,7 @@ def get_single_source(db: Session = Depends(get_db), name: str = None):
     "/json/level2/sources",
     description="Get information on different sources.",
     response_model=CursorPage[models.Level2SourceModel],
-    response_class=CustomJSONResponse,
+    response_class=CatalogResponse,
 )
 def get_level2_sources(db: Session = Depends(get_db), params: QueryParams = Depends()):
     if params.sort is None:
@@ -750,7 +754,7 @@ def get_level2_sources_aggregate(
     "/json/level2/sources/{uuid_}",
     description="Get information about a single signal",
     response_model=models.Level2SourceModel,
-    response_class=CustomJSONResponse,
+    response_class=DatasetResponse,
 )
 def get_level2_single_source(db: Session = Depends(get_db), uuid_: uuid.UUID = None):
     source = crud.get_level2_source(db, uuid_)

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -203,6 +203,10 @@ class CustomJSONResponse(JSONResponse):
         "version":     "schema:version",
         "source":      "dct:source",
         "timestamp":   "dct:date",
+        "distribution": "dcat:distribution",
+        "accessURL":    "dcat:accessURL",
+        "downloadURL":  "dcat:downloadURL",
+        "mediaType":    "dcat:mediaType",
     }
 
     _DEFINED_TERM_CONTEXT = {
@@ -264,17 +268,13 @@ class CustomJSONResponse(JSONResponse):
         self._strip_class_label_title(item)
         s3_url = item.pop("url", None)
         endpoint = item.pop("endpoint_url", None)
-        if isinstance(s3_url, str) and s3_url.startswith("s3://"):
-            distribution = {
+        if isinstance(s3_url, str) and s3_url.startswith("s3://") and endpoint:
+            item["distribution"] = [{
                 "@type": "dcat:Distribution",
-                "dcat:downloadURL": s3_url,
-                "dcat:mediaType": "application/zarr",
-            }
-            if endpoint:
-                distribution["dcat:accessURL"] = (
-                    f"{endpoint.rstrip('/')}/{s3_url[len('s3://'):]}"
-                )
-            item["dcat:distribution"] = [distribution]
+                "accessURL": SITE_URL,
+                "downloadURL": f"{endpoint.rstrip('/')}/{s3_url[len('s3://'):]}",
+                "mediaType": "application/zarr",
+            }]
         item["@type"] = "dcat:Dataset"
         return item
 

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -1,7 +1,6 @@
 import datetime
 import io
 import json
-import os
 import uuid
 from pathlib import Path
 from typing import List, Optional

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -189,18 +189,101 @@ class CustomJSONResponse(JSONResponse):
 
     media_type = "application/json"
 
+    _CONTEXT = {
+        "dcat":   "http://www.w3.org/ns/dcat#",
+        "dct":    "http://purl.org/dc/terms/",
+        "foaf":   "http://xmlns.com/foaf/0.1/",
+        "schema": "https://schema.org/",
+        "id":     "@id",
+        "type":   "@type",
+        "items":  "dcat:dataset",
+        "uuid":        "dct:identifier",
+        "description": "dct:description",
+        "name":        "schema:name",
+        "version":     "schema:version",
+        "source":      "dct:source",
+        "timestamp":   "dct:date",
+    }
+
+    _DEFINED_TERM_CONTEXT = {
+        "dct":    "http://purl.org/dc/terms/",
+        "schema": "https://schema.org/",
+        "type":   "@type",
+        "name":        "schema:name",
+        "description": "dct:description",
+    }
+
+    _CLASS_LABEL_TITLES = {
+        "Shot Dataset", "Signal Dataset", "Source Dataset",
+        "CPF Summary Item", "Tokamak Scenario",
+    }
+
     def render(self, content) -> bytes:
-        """
-        renders the output of the request
-        """
         content = self.convert_to_jsonld_terms(content)
         extracted_dict = {}
         edited_content = self.extract_meta_key(content, extracted_dict)
+        merged = {**extracted_dict, **edited_content}
 
-        # merge content with extracted context by placing context at the top
-        merged_content = {**extracted_dict, **edited_content}
+        if isinstance(merged, dict) and isinstance(merged.get("items"), list):
+            items = merged["items"]
+            if items and self._is_dataset(items[0]):
+                merged["@type"] = "dcat:Catalog"
+                merged["items"] = [self._to_dataset(it) for it in items]
+                merged["@context"] = self._CONTEXT
+            elif items and self._is_defined_term(items[0]):
+                merged["items"] = [self._to_defined_term(it) for it in items]
+                merged["@context"] = self._DEFINED_TERM_CONTEXT
+                merged.pop("@type", None)
+        elif isinstance(merged, dict) and self._is_dataset(merged):
+            # Single-record endpoint, e.g. /json/shots/{shot_id}.
+            merged = self._to_dataset(merged)
+            merged["@context"] = self._CONTEXT
 
-        return json.dumps(merged_content).encode()
+        return json.dumps(merged, default=str).encode()
+
+    @staticmethod
+    def _is_dataset(item):
+        return isinstance(item, dict) and ("shot_id" in item or "uuid" in item)
+
+    @staticmethod
+    def _is_defined_term(item):
+        if not isinstance(item, dict):
+            return False
+        if "shot_id" in item or "uuid" in item:
+            return False
+        return "index" in item or "id" in item
+
+    def _strip_class_label_title(self, item):
+        if item.get("title") in self._CLASS_LABEL_TITLES:
+            item.pop("title", None)
+
+    def _to_dataset(self, item):
+        if not isinstance(item, dict):
+            return item
+        self._strip_class_label_title(item)
+        s3_url = item.pop("url", None)
+        endpoint = item.pop("endpoint_url", None)
+        if isinstance(s3_url, str) and s3_url.startswith("s3://"):
+            distribution = {
+                "@type": "dcat:Distribution",
+                "dcat:downloadURL": s3_url,
+                "dcat:mediaType": "application/zarr",
+            }
+            if endpoint:
+                distribution["dcat:accessURL"] = (
+                    f"{endpoint.rstrip('/')}/{s3_url[len('s3://'):]}"
+                )
+            item["dcat:distribution"] = [distribution]
+        item["@type"] = "dcat:Dataset"
+        return item
+
+    def _to_defined_term(self, item):
+        """Type a row as schema:DefinedTerm and strip its class-label title."""
+        if not isinstance(item, dict):
+            return item
+        self._strip_class_label_title(item)
+        item["@type"] = "schema:DefinedTerm"
+        return item
 
     def convert_to_jsonld_terms(self, items):
         """

--- a/src/api/models.py
+++ b/src/api/models.py
@@ -33,25 +33,21 @@ class BaseSignalModel(SQLModel):
     title: str = Field(
         sa_column_kwargs={"server_default": "Signal Dataset"},
         description="the title of the dataset",
-        alias="dct__title",
     )
 
     uuid: uuid_pkg.UUID = Field(
         primary_key=True,
         default=None,
         description="UUID for a specific signal data",
-        alias="dct__identifier",
     )
 
     name: str = Field(
         description="Human readable name of this specific signal. A combination of the signal type and the shot number e.g. AMC_PLASMA_CURRENT",
-        alias="schema__name",
     )
 
     version: int = Field(
         sa_column_kwargs={"server_default": "0"},
         description="Version number of this dataset",
-        alias="schema__version",
     )
 
     rank: int = Field(description="Rank of the shape of this signal.")
@@ -64,7 +60,6 @@ class BaseSignalModel(SQLModel):
 
     source: str = Field(
         description="Name of the source this signal belongs to.",
-        alias="dct__source",
     )
 
     shape: Optional[List[int]] = Field(
@@ -85,7 +80,6 @@ class BaseSignalModel(SQLModel):
     description: str = Field(
         sa_column=Column(Text),
         description="The description of the dataset.",
-        alias="dct__description",
     )
 
     dimensions: Optional[List[str]] = Field(
@@ -155,20 +149,17 @@ class BaseSourceModel(SQLModel):
     title: str = Field(
         sa_column_kwargs={"server_default": "Source Dataset"},
         description="the title of the dataset",
-        alias="dct__title",
     )
 
     uuid: uuid_pkg.UUID = Field(
         primary_key=True,
         default=None,
         description="UUID for a specific source data",
-        alias="dct__identifier",
     )
 
     name: str = Field(
         nullable=False,
         description="Short name of the source.",
-        alias="schema__name",
     )
 
     url: str = Field(description="The URL for the location of this source.")
@@ -180,7 +171,6 @@ class BaseSourceModel(SQLModel):
     description: str = Field(
         sa_column=Column(Text),
         description="Description of this source",
-        alias="dct__description",
     )
 
     imas: Optional[str] = Field(
@@ -237,6 +227,14 @@ class DataService(SQLModel, table=True):
         description="Context mapping vocabulary to IRIs",
         alias="context_",
     )
+ 
+    jsonld: Optional[Dict] = Field(
+        sa_column=Column(JSONB),
+        description=(
+            "Complete serialised JSON-LD document for this service, "
+            "populated by ``create.create_serve_dataset``."
+        ),
+    )
 
     type: Optional[str] = Field(description="a structured set of data", alias="type_")
 
@@ -292,17 +290,14 @@ class CPFSummaryModel(SQLModel, table=True):
     title: str = Field(
         sa_column_kwargs={"server_default": "CPF Summary Item"},
         description="the title of the dataset",
-        alias="dct__title",
     )
 
     name: str = Field(
         sa_column=Column(Text),
         description="Name of the CPF variable.",
-        alias="schema__name",
     )
     description: str = Field(
         "Description of the CPF variable",
-        alias="dct__description",
     )
 
 
@@ -323,7 +318,6 @@ class ScenarioModel(SQLModel, table=True):
     title: str = Field(
         sa_column_kwargs={"server_default": "Tokamak Scenario"},
         description="the title of the dataset",
-        alias="dct__title",
     )
 
     id: int = Field(
@@ -332,7 +326,6 @@ class ScenarioModel(SQLModel, table=True):
     )
     name: str = Field(
         description="Name of the scenario.",
-        alias="schema__name",
     )
 
 
@@ -353,7 +346,6 @@ class BaseShotModel(SQLModel):
     title: str = Field(
         sa_column_kwargs={"server_default": "Shot Dataset"},
         description="the title of the dataset",
-        alias="dct__title",
     )
 
     shot_id: int = Field(
@@ -368,7 +360,6 @@ class BaseShotModel(SQLModel):
         index=True,
         default=None,
         description="UUID for this dataset",
-        alias="dct__identifier",
     )
 
     url: str = Field(
@@ -382,7 +373,6 @@ class BaseShotModel(SQLModel):
 
     timestamp: datetime.datetime = Field(
         description='Time the shot was fired in ISO 8601 format. e.g. "2023‐08‐10T09:51:19+00:00"',
-        alias="dct__date",
     )
 
     preshot_description: str = Field(

--- a/src/api/models.py
+++ b/src/api/models.py
@@ -19,7 +19,7 @@ from .types import (
 class BaseSignalModel(SQLModel):
     context: Optional[Dict] = Field(
         sa_column=Column(JSONB),
-        default=None,
+        default={},
         description="Context mapping vocabulary to IRIs",
         alias="context_",
     )
@@ -33,21 +33,25 @@ class BaseSignalModel(SQLModel):
     title: str = Field(
         sa_column_kwargs={"server_default": "Signal Dataset"},
         description="the title of the dataset",
+        alias="dct__title",
     )
 
     uuid: uuid_pkg.UUID = Field(
         primary_key=True,
         default=None,
         description="UUID for a specific signal data",
+        alias="dct__identifier",
     )
 
     name: str = Field(
         description="Human readable name of this specific signal. A combination of the signal type and the shot number e.g. AMC_PLASMA_CURRENT",
+        alias="schema__name",
     )
 
     version: int = Field(
         sa_column_kwargs={"server_default": "0"},
         description="Version number of this dataset",
+        alias="schema__version",
     )
 
     rank: int = Field(description="Rank of the shape of this signal.")
@@ -58,7 +62,10 @@ class BaseSignalModel(SQLModel):
         description="The URL for the S3 endpoint location of this signal."
     )
 
-    source: str = Field(description="Name of the source this signal belongs to.")
+    source: str = Field(
+        description="Name of the source this signal belongs to.",
+        alias="dct__source",
+    )
 
     shape: Optional[List[int]] = Field(
         sa_column=Column(ARRAY(Integer)),
@@ -76,7 +83,9 @@ class BaseSignalModel(SQLModel):
     )
 
     description: str = Field(
-        sa_column=Column(Text), description="The description of the dataset."
+        sa_column=Column(Text),
+        description="The description of the dataset.",
+        alias="dct__description",
     )
 
     dimensions: Optional[List[str]] = Field(
@@ -132,7 +141,7 @@ class Level2SignalModel(BaseSignalModel, table=True):
 class BaseSourceModel(SQLModel):
     context: Optional[Dict] = Field(
         sa_column=Column(JSONB),
-        default=None,
+        default={},
         description="Context mapping vocabulary to IRIs",
         alias="context_",
     )
@@ -146,15 +155,21 @@ class BaseSourceModel(SQLModel):
     title: str = Field(
         sa_column_kwargs={"server_default": "Source Dataset"},
         description="the title of the dataset",
+        alias="dct__title",
     )
 
     uuid: uuid_pkg.UUID = Field(
         primary_key=True,
         default=None,
         description="UUID for a specific source data",
+        alias="dct__identifier",
     )
 
-    name: str = Field(nullable=False, description="Short name of the source.")
+    name: str = Field(
+        nullable=False,
+        description="Short name of the source.",
+        alias="schema__name",
+    )
 
     url: str = Field(description="The URL for the location of this source.")
 
@@ -163,7 +178,9 @@ class BaseSourceModel(SQLModel):
     )
 
     description: str = Field(
-        sa_column=Column(Text), description="Description of this source"
+        sa_column=Column(Text),
+        description="Description of this source",
+        alias="dct__description",
     )
 
     imas: Optional[str] = Field(
@@ -221,12 +238,6 @@ class DataService(SQLModel, table=True):
         alias="context_",
     )
 
-    jsonld: Optional[Dict] = Field(
-        sa_column=Column(JSONB),
-        default=None,
-        description="Canonical JSON-LD representation of the dataset",
-    )
-
     type: Optional[str] = Field(description="a structured set of data", alias="type_")
 
     id: Optional[str] = Field(
@@ -267,8 +278,8 @@ class CPFSummaryModel(SQLModel, table=True):
 
     context: Optional[Dict] = Field(
         sa_column=Column(JSONB),
-        default=None,
-        description="Context mapping vocabulary to IRIs. Unused at render time — the API emits its own @context — kept Optional so legacy rows with NULL still deserialize.",
+        default={},
+        description="Context mapping vocabulary to IRIs",
         alias="context_",
     )
 
@@ -281,10 +292,18 @@ class CPFSummaryModel(SQLModel, table=True):
     title: str = Field(
         sa_column_kwargs={"server_default": "CPF Summary Item"},
         description="the title of the dataset",
+        alias="dct__title",
     )
 
-    name: str = Field(sa_column=Column(Text), description="Name of the CPF variable.")
-    description: str = Field("Description of the CPF variable")
+    name: str = Field(
+        sa_column=Column(Text),
+        description="Name of the CPF variable.",
+        alias="schema__name",
+    )
+    description: str = Field(
+        "Description of the CPF variable",
+        alias="dct__description",
+    )
 
 
 class ScenarioModel(SQLModel, table=True):
@@ -292,8 +311,8 @@ class ScenarioModel(SQLModel, table=True):
 
     context: Optional[Dict] = Field(
         sa_column=Column(JSONB),
-        default=None,
-        description="Context mapping vocabulary to IRIs. Unused at render time — the API emits its own @context — kept Optional so legacy rows with NULL still deserialize.",
+        default={},
+        description="Context mapping vocabulary to IRIs",
         alias="context_",
     )
     type: str = Field(
@@ -304,20 +323,24 @@ class ScenarioModel(SQLModel, table=True):
     title: str = Field(
         sa_column_kwargs={"server_default": "Tokamak Scenario"},
         description="the title of the dataset",
+        alias="dct__title",
     )
 
     id: int = Field(
         primary_key=True,
         nullable=False,
     )
-    name: str = Field(description="Name of the scenario.")
+    name: str = Field(
+        description="Name of the scenario.",
+        alias="schema__name",
+    )
 
 
 class BaseShotModel(SQLModel):
     context: Optional[Dict] = Field(
         sa_column=Column(JSONB),
-        default=None,
-        description="Context mapping vocabulary to IRIs. Unused at render time — the API emits its own @context — kept Optional so legacy rows with NULL still deserialize.",
+        default={},
+        description="Context mapping vocabulary to IRIs",
         alias="context_",
     )
 
@@ -330,6 +353,7 @@ class BaseShotModel(SQLModel):
     title: str = Field(
         sa_column_kwargs={"server_default": "Shot Dataset"},
         description="the title of the dataset",
+        alias="dct__title",
     )
 
     shot_id: int = Field(
@@ -344,6 +368,7 @@ class BaseShotModel(SQLModel):
         index=True,
         default=None,
         description="UUID for this dataset",
+        alias="dct__identifier",
     )
 
     url: str = Field(
@@ -357,6 +382,7 @@ class BaseShotModel(SQLModel):
 
     timestamp: datetime.datetime = Field(
         description='Time the shot was fired in ISO 8601 format. e.g. "2023‐08‐10T09:51:19+00:00"',
+        alias="dct__date",
     )
 
     preshot_description: str = Field(

--- a/src/api/models.py
+++ b/src/api/models.py
@@ -221,6 +221,12 @@ class DataService(SQLModel, table=True):
         alias="context_",
     )
 
+    jsonld: Optional[Dict] = Field(
+        sa_column=Column(JSONB),
+        default=None,
+        description="Canonical JSON-LD representation of the dataset",
+    )
+
     type: Optional[str] = Field(description="a structured set of data", alias="type_")
 
     id: Optional[str] = Field(

--- a/src/api/models.py
+++ b/src/api/models.py
@@ -17,9 +17,9 @@ from .types import (
 
 
 class BaseSignalModel(SQLModel):
-    context: Dict = Field(
+    context: Optional[Dict] = Field(
         sa_column=Column(JSONB),
-        default={},
+        default=None,
         description="Context mapping vocabulary to IRIs",
         alias="context_",
     )
@@ -130,9 +130,9 @@ class Level2SignalModel(BaseSignalModel, table=True):
 
 
 class BaseSourceModel(SQLModel):
-    context: Dict = Field(
+    context: Optional[Dict] = Field(
         sa_column=Column(JSONB),
-        default={},
+        default=None,
         description="Context mapping vocabulary to IRIs",
         alias="context_",
     )
@@ -259,10 +259,10 @@ class CPFSummaryModel(SQLModel, table=True):
 
     index: int = Field(primary_key=True, nullable=False)
 
-    context: Dict = Field(
+    context: Optional[Dict] = Field(
         sa_column=Column(JSONB),
-        default={},
-        description="Context mapping vocabulary to IRIs",
+        default=None,
+        description="Context mapping vocabulary to IRIs. Unused at render time — the API emits its own @context — kept Optional so legacy rows with NULL still deserialize.",
         alias="context_",
     )
 
@@ -284,10 +284,10 @@ class CPFSummaryModel(SQLModel, table=True):
 class ScenarioModel(SQLModel, table=True):
     __tablename__ = "scenarios"
 
-    context: Dict = Field(
+    context: Optional[Dict] = Field(
         sa_column=Column(JSONB),
-        default={},
-        description="Context mapping vocabulary to IRIs",
+        default=None,
+        description="Context mapping vocabulary to IRIs. Unused at render time — the API emits its own @context — kept Optional so legacy rows with NULL still deserialize.",
         alias="context_",
     )
     type: str = Field(
@@ -308,10 +308,10 @@ class ScenarioModel(SQLModel, table=True):
 
 
 class BaseShotModel(SQLModel):
-    context: Dict = Field(
+    context: Optional[Dict] = Field(
         sa_column=Column(JSONB),
-        default={},
-        description="Context mapping vocabulary to IRIs",
+        default=None,
+        description="Context mapping vocabulary to IRIs. Unused at render time — the API emits its own @context — kept Optional so legacy rows with NULL still deserialize.",
         alias="context_",
     )
 

--- a/src/api/utils.py
+++ b/src/api/utils.py
@@ -5,6 +5,10 @@ from sqlalchemy import func
 from sqlalchemy.sql.operators import is_, is_not
 from sqlmodel.main import SQLModel
 
+from rdflib import Graph, Namespace, URIRef, Literal
+from rdflib.namespace import DCAT, DCTERMS, FOAF, RDF, SKOS
+
+
 
 def is_optional(type_):
     """Check if a type is optional. For example t.Optional[int] is optional,"""
@@ -81,6 +85,34 @@ def create_model_column_metadata(model_cls):
             else:
                 metadata[name] = "object"
     return metadata
+
+def get_context_for_graph(g):
+    # 1. Find all namespaces that are actually used in the graph
+    used_namespaces = set()
+    for s, p, o in g:
+        if isinstance(p, URIRef):
+            used_namespaces.add(str(p.rsplit('#', 1)[0]) + '#') if '#' in p else used_namespaces.add(str(p.rsplit('/', 1)[0]) + '/')
+        if p == RDF.type and isinstance(o, URIRef):
+            used_namespaces.add(str(o.rsplit('#', 1)[0]) + '#') if '#' in o else used_namespaces.add(str(o.rsplit('/', 1)[0]) + '/')
+    
+    # 2. Build a minimal context from the prefixes you bound in `bind_base_namespaces`
+    dynamic_context = {}
+    for prefix, namespace in g.namespace_manager.namespaces():
+        if str(namespace) in used_namespaces:
+            dynamic_context[prefix] = str(namespace)
+    
+    return dynamic_context
+
+SCHEMA = Namespace("https://schema.org/")
+
+def bind_base_namespaces(graph):
+    graph.bind("dcat", DCAT)
+    graph.bind("dct", DCTERMS)
+    graph.bind("schema", SCHEMA)
+    graph.bind("foaf", FOAF)
+    graph.bind("skos", SKOS)
+    return graph
+
 
 
 comparator_map = {

--- a/src/api/utils.py
+++ b/src/api/utils.py
@@ -1,13 +1,11 @@
 import typing as t
 
 from pydantic import create_model
+from rdflib import Namespace, URIRef
+from rdflib.namespace import DCAT, DCTERMS, FOAF, RDF, SKOS
 from sqlalchemy import func
 from sqlalchemy.sql.operators import is_, is_not
 from sqlmodel.main import SQLModel
-
-from rdflib import Graph, Namespace, URIRef, Literal
-from rdflib.namespace import DCAT, DCTERMS, FOAF, RDF, SKOS
-
 
 
 def is_optional(type_):


### PR DESCRIPTION
In response to issue: #172 and discussions with Alejandra.

The JSON endpoints previously declared DCAT terms in the `@context` inconsistently, every response was a flat dcat:Dataset regardless of whether it was a catalogue listing, a dataset, or a glossary entry. This PR reshapes the responses to be more inline with DCAT usage.

Example of new structure after snippet put into [json-ld playground](https://json-ld.org/playground/):

`http://localhost:8081/json/shots` :
```
{
  "@type": "http://www.w3.org/ns/dcat#Catalog",
  "http://www.w3.org/ns/dcat#dataset": [
    {
      "@type": "http://www.w3.org/ns/dcat#Dataset",
      "http://purl.org/dc/terms/date": "2004-12-13T11:54:00",
      "http://purl.org/dc/terms/identifier": "219e5d59-b9dc-584f-b83b-018c47e8739d",
      "http://www.w3.org/ns/dcat#distribution": {
        "@type": "http://www.w3.org/ns/dcat#Distribution",
        "http://www.w3.org/ns/dcat#accessURL": "https://s3.echo.stfc.ac.uk/mast/level1/shots/11695.zarr",
        "http://www.w3.org/ns/dcat#downloadURL": "s3://mast/level1/shots/11695.zarr",
        "http://www.w3.org/ns/dcat#mediaType": "application/zarr"
      }
    },
    {
      "@type": "http://www.w3.org/ns/dcat#Dataset",
      "http://purl.org/dc/terms/date": "2004-12-13T12:07:00",
      "http://purl.org/dc/terms/identifier": "9ba69c96-34ac-5cd4-a1b8-8e9d7a44f871",
      "http://www.w3.org/ns/dcat#distribution": {
        "@type": "http://www.w3.org/ns/dcat#Distribution",
        "http://www.w3.org/ns/dcat#accessURL": "https://s3.echo.stfc.ac.uk/mast/level1/shots/11696.zarr",
        "http://www.w3.org/ns/dcat#downloadURL": "s3://mast/level1/shots/11696.zarr",
        "http://www.w3.org/ns/dcat#mediaType": "application/zarr"
      }
```

Single shot endpoint (`http://localhost:8081/json/shots/11695`):

```
{
  "@type": "http://www.w3.org/ns/dcat#Dataset",
  "http://purl.org/dc/terms/date": "2004-12-13T11:54:00",
  "http://purl.org/dc/terms/identifier": "219e5d59-b9dc-584f-b83b-018c47e8739d",
  "http://www.w3.org/ns/dcat#distribution": {
    "@type": "http://www.w3.org/ns/dcat#Distribution",
    "http://www.w3.org/ns/dcat#accessURL": "https://s3.echo.stfc.ac.uk/mast/level1/shots/11695.zarr",
    "http://www.w3.org/ns/dcat#downloadURL": "s3://mast/level1/shots/11695.zarr",
    "http://www.w3.org/ns/dcat#mediaType": "application/zarr"
  }
}
```

Due to cpf summary not being a dataset, changed the context to more appropriate definition:

```
{
  "@context": {
    "dct": "http://purl.org/dc/terms/",
    "schema": "https://schema.org/",
    "type": "@type",
    "name": "schema:name",
    "description": "dct:description"
  },
  "type": "schema:DefinedTermSet",
  "schema:hasDefinedTerm": [
    {
      "type": "schema:DefinedTerm",
      "description": "CP3c Set Volts",
      "name": "mcs_cp3c_volt"
    },
    {
      "type": "schema:DefinedTerm",
      "description": "Additive Gas Plenum",
      "name": "mcs_additive_gas_pressure"
    },
```