### PR TITLE
Add dataset landing pages with schema.org + DCAT JSON-LD

### DIFF
--- a/src/api/dataset_metadata.py
+++ b/src/api/dataset_metadata.py
@@ -1,0 +1,81 @@
+"""Static metadata used by the schema.org and DCAT JSON-LD builders.
+
+Values that apply uniformly across all MAST/MAST-U shots live here as
+constants. Per-shot variation (timestamp, scenario, signals, etc.) comes
+from the database, not this module.
+"""
+
+LICENSE_URL = "https://creativecommons.org/licenses/by/4.0/"
+LICENSE_NAME = "Creative Commons Attribution 4.0 International (CC-BY-4.0)"
+
+PUBLISHER = {
+    "@id": "https://ror.org/05nbnja43",
+    "@type": "Organization",
+    "name": "UK Atomic Energy Authority",
+    "url": "https://ccfe.ukaea.uk/",
+}
+
+FUNDER = {
+    "@type": "Organization",
+    "name": "UK Atomic Energy Authority",
+    "url": "https://ccfe.ukaea.uk/",
+}
+
+CONTACT_POINT = {
+    "@type": "ContactPoint",
+    "contactType": "Data curator",
+    "email": "fair-mast@ukaea.uk",
+}
+
+TOP_LEVEL_KEYWORDS = [
+    "fusion",
+    "tokamak",
+    "plasma physics",
+    "MAST",
+    "MAST-U",
+    "magnetic confinement fusion",
+    "spherical tokamak",
+]
+
+CATALOG_NAME = "FAIR MAST Data Archive"
+CATALOG_DESCRIPTION = (
+    "Open experimental data from the MAST and MAST-U spherical tokamaks "
+    "operated by the UK Atomic Energy Authority. Includes plasma physics "
+    "signals, source diagnostic data, and per-shot metadata for fusion "
+    "research."
+)
+
+MEASUREMENT_TECHNIQUE = "Magnetic confinement fusion plasma diagnostics"
+
+
+def catalog_url(site_url: str) -> str:
+    return f"{site_url}/catalog"
+
+
+def shot_page_url(site_url: str, shot_id: int, level: int = 1) -> str:
+    return f"{site_url}/dataset/level{level}/shot/{shot_id}"
+
+
+def shot_jsonld_url(site_url: str, shot_id: int, level: int = 1) -> str:
+    return f"{site_url}/dataset/level{level}/shot/{shot_id}.jsonld"
+
+
+def level_label(level: int) -> str:
+    """Human-readable label for a processing level (used in titles, keywords)."""
+    return f"Level {level}"
+
+
+def s3_to_http(s3_url: str | None, endpoint_url: str | None) -> str | None:
+    """Convert an ``s3://bucket/key`` URL to ``{endpoint_url}/bucket/key``.
+
+    Returns the original URL unchanged if it isn't an s3:// URL, or if no
+    endpoint is available. Browsers and Googlebot can't follow s3:// URLs,
+    so distribution / accessURL values need the HTTP form.
+    """
+    if not s3_url:
+        return s3_url
+    if not s3_url.startswith("s3://"):
+        return s3_url
+    if not endpoint_url:
+        return s3_url
+    return f"{endpoint_url.rstrip('/')}/{s3_url[len('s3://'):]}"

--- a/src/api/jsonld_dcat.py
+++ b/src/api/jsonld_dcat.py
@@ -1,0 +1,217 @@
+"""DCAT 3 JSON-LD builders for MAST datasets.
+
+Served as alternate representations at ``/dataset/shot/{id}.jsonld`` for
+DCAT-AP harvesters (B2FIND, OpenAIRE, re3data, EOSC). Companion to
+``jsonld_schemaorg`` (which targets Google Dataset Search via HTML
+embedding); both describe the same underlying data, in different
+vocabularies.
+
+The JSON-LD context mirrors the prefix mappings in ``create.base_context``
+(see ``_DCAT_CONTEXT`` below — kept in sync manually to avoid pulling
+create.py's heavy deps into the request path). The graph is built
+explicitly; we don't route through ``CustomJSONResponse.convert_to_jsonld_terms``,
+which is opaque field-name munging meant for the JSON API.
+"""
+
+import datetime
+from typing import Iterable
+
+from . import dataset_metadata as meta
+from .models import BaseSourceModel, Level2ShotModel, ShotModel
+
+# Either processing-level model is acceptable as input — both inherit from
+# ShotLike but the enum fields we read (facility, divertor_config, etc.)
+# live on the subclasses, not on the base.
+ShotLike = ShotModel | Level2ShotModel
+
+# Mirrors src/api/create.py:base_context (which can't be imported from the
+# request path because create.py pulls in dask/pyarrow/psycopg2). Keep in
+# sync if create.py's prefix table is extended.
+_DCAT_CONTEXT = {
+    "dcat": "http://www.w3.org/ns/dcat#",
+    "dct": "http://purl.org/dc/terms/",
+    "foaf": "http://xmlns.com/foaf/0.1/",
+    "schema": "https://schema.org",
+    "dqv": "http://www.w3.org/ns/dqv#",
+    "sdmx-measure": "http://purl.org/linked-data/sdmx/2009/measure#",
+    "prov": "http://www.w3.org/ns/prov#",
+    "owl": "http://www.w3.org/2002/07/owl#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+}
+
+
+def _context() -> dict:
+    return dict(_DCAT_CONTEXT)
+
+
+def _publisher_node() -> dict:
+    return {
+        "@id": meta.PUBLISHER["@id"],
+        "@type": "foaf:Organization",
+        "foaf:name": meta.PUBLISHER["name"],
+        "foaf:homepage": {"@id": meta.PUBLISHER["url"]},
+    }
+
+
+def _license_node() -> dict:
+    return {"@id": meta.LICENSE_URL}
+
+
+def _temporal_node(shot: ShotLike) -> dict:
+    start = shot.timestamp
+    end = start + datetime.timedelta(seconds=1)
+    return {
+        "@type": "dct:PeriodOfTime",
+        "dcat:startDate": {"@value": start.isoformat(), "@type": "xsd:dateTime"},
+        "dcat:endDate": {"@value": end.isoformat(), "@type": "xsd:dateTime"},
+    }
+
+
+def _distributions(shot: ShotLike, site_url: str) -> list[dict]:
+    dists: list[dict] = []
+    zarr_url = meta.s3_to_http(shot.url, shot.endpoint_url)
+    if zarr_url:
+        dists.append(
+            {
+                "@type": "dcat:Distribution",
+                "dct:title": "Zarr store",
+                "dcat:accessURL": {"@id": zarr_url},
+                "dct:format": "application/vnd.zarr",
+                "dcat:mediaType": "application/vnd.zarr",
+            }
+        )
+    dists.append(
+        {
+            "@type": "dcat:Distribution",
+            "dct:title": "Parquet metadata export",
+            "dcat:accessURL": {
+                "@id": f"{site_url}/parquet/shots?filters=shot_id$eq:{shot.shot_id}"
+            },
+            "dct:format": "application/parquet",
+            "dcat:mediaType": "application/parquet",
+        }
+    )
+    dists.append(
+        {
+            "@type": "dcat:Distribution",
+            "dct:title": "JSON metadata",
+            "dcat:accessURL": {"@id": f"{site_url}/json/shots/{shot.shot_id}"},
+            "dct:format": "application/json",
+            "dcat:mediaType": "application/json",
+        }
+    )
+    return dists
+
+
+def _keywords(shot: ShotLike, level: int) -> list[str]:
+    derived: list[str] = [meta.level_label(level), shot.facility.value]
+    if shot.campaign:
+        derived.append(f"campaign {shot.campaign}")
+    if shot.divertor_config:
+        derived.append(str(shot.divertor_config.value))
+    if shot.plasma_shape:
+        derived.append(str(shot.plasma_shape.value))
+    if shot.current_range:
+        derived.append(str(shot.current_range.value))
+    seen: set[str] = set()
+    out: list[str] = []
+    for kw in derived + list(meta.TOP_LEVEL_KEYWORDS):
+        if kw not in seen:
+            seen.add(kw)
+            out.append(kw)
+    return out
+
+
+def _description(shot: ShotLike, level: int) -> str:
+    parts: list[str] = [
+        f"{meta.level_label(level)} experimental data from {shot.facility.value} "
+        f"shot {shot.shot_id}"
+        + (f", campaign {shot.campaign}" if shot.campaign else "")
+        + "."
+    ]
+    if shot.preshot_description:
+        parts.append(f"Pre-shot plan: {shot.preshot_description.strip()}")
+    if shot.postshot_description:
+        parts.append(f"Post-shot observations: {shot.postshot_description.strip()}")
+    return " ".join(parts)
+
+
+def build_shot_dataset_dcat(
+    shot: ShotLike,
+    sources: Iterable[BaseSourceModel],
+    site_url: str,
+    level: int = 1,
+    related_level_url: str | None = None,
+) -> dict:
+    """Build a DCAT 3 ``dcat:Dataset`` JSON-LD document for a single shot.
+
+    ``level`` is the processing level (1 or 2). When ``related_level_url`` is
+    supplied, the document encodes the derivation relationship via
+    ``dct:source`` (level 2 → level 1) or ``dct:hasVersion`` (level 1 →
+    level 2).
+    """
+    sources = list(sources)
+    page_url = meta.shot_page_url(site_url, shot.shot_id, level)
+    catalog_url = meta.catalog_url(site_url)
+
+    title = f"{shot.facility.value.upper()} shot {shot.shot_id} ({meta.level_label(level)})"
+
+    doc: dict = {
+        "@context": _context(),
+        "@id": page_url,
+        "@type": "dcat:Dataset",
+        "dct:title": title,
+        "dct:description": _description(shot, level),
+        "dct:identifier": str(shot.uuid) if shot.uuid else str(shot.shot_id),
+        "dct:license": _license_node(),
+        "dct:publisher": _publisher_node(),
+        "dct:creator": _publisher_node(),
+        "dcat:keyword": _keywords(shot, level),
+        "dcat:distribution": _distributions(shot, site_url),
+        "dct:isPartOf": {"@id": catalog_url},
+        "owl:sameAs": {"@id": page_url},
+    }
+
+    if related_level_url:
+        if level == 2:
+            doc["dct:source"] = {"@id": related_level_url}
+        else:
+            doc["dct:hasVersion"] = {"@id": related_level_url}
+
+    doc["dct:issued"] = {
+        "@value": shot.timestamp.date().isoformat(),
+        "@type": "xsd:date",
+    }
+    doc["dct:modified"] = {
+        "@value": shot.timestamp.date().isoformat(),
+        "@type": "xsd:date",
+    }
+    doc["dct:temporal"] = _temporal_node(shot)
+
+    if sources:
+        parts: list[dict] = []
+        for src in sources:
+            src_url = meta.s3_to_http(src.url, src.endpoint_url)
+            part = {
+                "@type": "dcat:Dataset",
+                "dct:title": src.name,
+                "dct:description": src.description
+                or f"{src.name} diagnostic data for shot {shot.shot_id}.",
+                "dct:identifier": str(src.uuid) if src.uuid else src.name,
+                "dcat:distribution": (
+                    [
+                        {
+                            "@type": "dcat:Distribution",
+                            "dcat:accessURL": {"@id": src_url},
+                            "dct:format": "application/vnd.zarr",
+                            "dcat:mediaType": "application/vnd.zarr",
+                        }
+                    ]
+                    if src_url
+                    else []
+                ),
+            }
+            parts.append(part)
+        doc["dct:hasPart"] = parts
+
+    return doc

--- a/src/api/jsonld_schemaorg.py
+++ b/src/api/jsonld_schemaorg.py
@@ -1,0 +1,228 @@
+"""schema.org Dataset JSON-LD builders for MAST landing pages.
+
+Embedded in HTML pages via ``<script type="application/ld+json">`` so Google
+Dataset Search indexes them. Builders are pure functions returning dicts;
+templates serialise via ``tojson``.
+"""
+
+import datetime
+from typing import Iterable
+
+from . import dataset_metadata as meta
+from .models import BaseSourceModel, Level2ShotModel, ShotModel
+
+# Either processing-level model is acceptable as input — both inherit from
+# ShotLike but the enum fields we read (facility, divertor_config, etc.)
+# live on the subclasses, not on the base.
+ShotLike = ShotModel | Level2ShotModel
+
+
+def _shot_name(shot: ShotLike, level: int) -> str:
+    return f"{shot.facility.value.upper()} shot {shot.shot_id} ({meta.level_label(level)})"
+
+
+def _shot_description(shot: ShotLike, level: int) -> str:
+    parts: list[str] = [
+        f"{meta.level_label(level)} experimental data from {shot.facility.value} "
+        f"shot {shot.shot_id}"
+        + (f", campaign {shot.campaign}" if shot.campaign else "")
+        + "."
+    ]
+
+    if shot.preshot_description:
+        parts.append(f"Pre-shot plan: {shot.preshot_description.strip()}")
+    if shot.postshot_description:
+        parts.append(f"Post-shot observations: {shot.postshot_description.strip()}")
+
+    return " ".join(parts)
+
+
+def _shot_keywords(shot: ShotLike, level: int) -> list[str]:
+    derived: list[str] = [meta.level_label(level), shot.facility.value]
+    if shot.campaign:
+        derived.append(f"campaign {shot.campaign}")
+    if shot.divertor_config:
+        derived.append(str(shot.divertor_config.value))
+    if shot.plasma_shape:
+        derived.append(str(shot.plasma_shape.value))
+    if shot.current_range:
+        derived.append(str(shot.current_range.value))
+    seen: set[str] = set()
+    out: list[str] = []
+    for kw in derived + list(meta.TOP_LEVEL_KEYWORDS):
+        if kw not in seen:
+            seen.add(kw)
+            out.append(kw)
+    return out
+
+
+def _temporal_coverage(shot: ShotLike) -> str:
+    # MAST plasma pulses last ~1s; the timestamp marks the pulse start.
+    start = shot.timestamp
+    end = start + datetime.timedelta(seconds=1)
+    return f"{start.isoformat()}/{end.isoformat()}"
+
+
+def _identifiers(shot: ShotLike, site_url: str) -> list[dict]:
+    ids: list[dict] = [
+        {
+            "@type": "PropertyValue",
+            "propertyID": "shot_id",
+            "value": str(shot.shot_id),
+        }
+    ]
+    if shot.uuid:
+        ids.append(
+            {
+                "@type": "PropertyValue",
+                "propertyID": "uuid",
+                "value": str(shot.uuid),
+            }
+        )
+    return ids
+
+
+def _distributions(shot: ShotLike, site_url: str) -> list[dict]:
+    dists: list[dict] = []
+    zarr_url = meta.s3_to_http(shot.url, shot.endpoint_url)
+    if zarr_url:
+        dists.append(
+            {
+                "@type": "DataDownload",
+                "encodingFormat": "application/vnd.zarr",
+                "contentUrl": zarr_url,
+                "name": "Zarr store (full shot data)",
+            }
+        )
+    dists.append(
+        {
+            "@type": "DataDownload",
+            "encodingFormat": "application/parquet",
+            "contentUrl": f"{site_url}/parquet/shots?filters=shot_id$eq:{shot.shot_id}",
+            "name": "Parquet metadata export",
+        }
+    )
+    dists.append(
+        {
+            "@type": "DataDownload",
+            "encodingFormat": "application/json",
+            "contentUrl": f"{site_url}/json/shots/{shot.shot_id}",
+            "name": "JSON metadata",
+        }
+    )
+    return dists
+
+
+def _variable_measured(sources: Iterable[BaseSourceModel]) -> list[dict]:
+    # Curated list of diagnostic systems (sources), capped — these are what
+    # researchers actually search for, e.g. "Thomson scattering MAST".
+    out: list[dict] = []
+    seen: set[str] = set()
+    for src in sources:
+        if src.name in seen:
+            continue
+        seen.add(src.name)
+        item = {
+            "@type": "PropertyValue",
+            "name": src.name,
+            "propertyID": src.name,
+        }
+        if src.description:
+            item["description"] = src.description
+        out.append(item)
+        if len(out) >= 10:
+            break
+    return out
+
+
+def _has_part(sources: Iterable[BaseSourceModel], shot: ShotLike) -> list[dict]:
+    parts: list[dict] = []
+    for src in sources:
+        part: dict = {
+            "@type": "Dataset",
+            "name": src.name,
+            "description": src.description or f"{src.name} diagnostic data for shot {shot.shot_id}.",
+        }
+        src_url = meta.s3_to_http(src.url, src.endpoint_url)
+        if src_url:
+            part["distribution"] = {
+                "@type": "DataDownload",
+                "encodingFormat": "application/vnd.zarr",
+                "contentUrl": src_url,
+            }
+        if src.uuid:
+            part["identifier"] = {
+                "@type": "PropertyValue",
+                "propertyID": "uuid",
+                "value": str(src.uuid),
+            }
+        parts.append(part)
+    return parts
+
+
+def build_shot_dataset_jsonld(
+    shot: ShotLike,
+    sources: Iterable[BaseSourceModel],
+    site_url: str,
+    level: int = 1,
+    related_level_url: str | None = None,
+) -> dict:
+    """Build a schema.org/Dataset JSON-LD document for a single MAST shot.
+
+    The output is intended to be embedded in an HTML landing page via
+    ``<script type="application/ld+json">`` for Google Dataset Search.
+
+    ``level`` is the processing level (1 or 2). When ``related_level_url`` is
+    supplied, the document links to the counterpart at the other processing
+    level via ``isBasedOn`` (level 2 → level 1) or ``subjectOf`` (level 1 →
+    level 2).
+    """
+    sources = list(sources)
+    page_url = meta.shot_page_url(site_url, shot.shot_id, level)
+    catalog_url = meta.catalog_url(site_url)
+
+    doc: dict = {
+        "@context": "https://schema.org",
+        "@type": "Dataset",
+        "@id": page_url,
+        "name": _shot_name(shot, level),
+        "description": _shot_description(shot, level),
+        "url": page_url,
+        "sameAs": meta.shot_jsonld_url(site_url, shot.shot_id, level),
+        "identifier": _identifiers(shot, site_url),
+        "license": meta.LICENSE_URL,
+        "isAccessibleForFree": True,
+        "creator": meta.PUBLISHER,
+        "publisher": meta.PUBLISHER,
+        "funder": meta.FUNDER,
+        "keywords": _shot_keywords(shot, level),
+        "measurementTechnique": meta.MEASUREMENT_TECHNIQUE,
+        "distribution": _distributions(shot, site_url),
+        "includedInDataCatalog": {
+            "@type": "DataCatalog",
+            "@id": catalog_url,
+            "name": meta.CATALOG_NAME,
+            "url": catalog_url,
+        },
+        "isPartOf": catalog_url,
+    }
+
+    if related_level_url:
+        if level == 2:
+            doc["isBasedOn"] = {"@type": "Dataset", "@id": related_level_url}
+        else:
+            doc["subjectOf"] = {"@type": "Dataset", "@id": related_level_url}
+
+    doc["datePublished"] = shot.timestamp.date().isoformat()
+    doc["dateModified"] = shot.timestamp.date().isoformat()
+    doc["temporalCoverage"] = _temporal_coverage(shot)
+
+    variables = _variable_measured(sources)
+    if variables:
+        doc["variableMeasured"] = variables
+
+    parts = _has_part(sources, shot)
+    if parts:
+        doc["hasPart"] = parts
+
+    return doc

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -13,7 +13,7 @@ import ujson
 from fastapi import Depends, FastAPI, HTTPException, Query, Request, Response, status
 from fastapi.encoders import jsonable_encoder
 from fastapi.exceptions import RequestValidationError
-from fastapi.responses import JSONResponse, StreamingResponse
+from fastapi.responses import HTMLResponse, JSONResponse, StreamingResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 from fastapi_pagination import add_pagination
@@ -24,7 +24,7 @@ from strawberry.asgi import GraphQL
 from strawberry.http import GraphQLHTTPResponse
 from strawberry.types import ExecutionResult
 
-from . import crud, graphql, models
+from . import crud, dataset_metadata, graphql, jsonld_dcat, jsonld_schemaorg, models
 from .database import get_db
 
 templates = Jinja2Templates(directory="src/api/templates")
@@ -908,5 +908,148 @@ if len(list(docs_built.iterdir())) > 1:
     docs_directory = "./docs/built/_build/html"
 else:
     docs_directory = "./docs/default"
+
+
+_SHOT_MODEL_BY_LEVEL = {
+    1: (models.ShotModel, models.Level2ShotModel),
+    2: (models.Level2ShotModel, models.ShotModel),
+}
+# Maps level -> (own model, counterpart model). Used to load the requested
+# level and to detect whether the same shot_id exists at the other level
+# (so we can emit a cross-link).
+
+
+def _load_shot_for_landing(db: Session, shot_id: int, level: int):
+    """Fetch a shot at the given processing level via SQLModel.
+
+    Returns the ORM object (not a dict, unlike ``crud.get_shot``) plus a
+    boolean indicating whether the same shot exists at the other level.
+    """
+    own_model, other_model = _SHOT_MODEL_BY_LEVEL[level]
+    shot = db.get(own_model, shot_id)
+    if shot is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Level {level} shot {shot_id} not found",
+        )
+    other_exists = db.get(other_model, shot_id) is not None
+    return shot, other_exists
+
+
+def _render_shot_landing(
+    request: Request,
+    db: Session,
+    shot_id: int,
+    level: int,
+) -> Response:
+    shot, other_exists = _load_shot_for_landing(db, shot_id, level)
+    sources = list(shot.sources)
+    related_level = None
+    related_level_url = None
+    if other_exists:
+        other = 2 if level == 1 else 1
+        related_level_url = dataset_metadata.shot_page_url(SITE_URL, shot_id, other)
+        related_level = {
+            "url": related_level_url,
+            "label": f"{dataset_metadata.level_label(other)} version of this shot",
+            "relation": (
+                "derived from this dataset"
+                if level == 1
+                else "the calibrated-raw dataset this is derived from"
+            ),
+        }
+    jsonld = jsonld_schemaorg.build_shot_dataset_jsonld(
+        shot, sources, SITE_URL, level=level, related_level_url=related_level_url
+    )
+    facility = shot.facility.value
+    shot_title = f"{facility.upper()} shot {shot.shot_id} ({dataset_metadata.level_label(level)})"
+    description = (
+        f"{dataset_metadata.level_label(level)} experimental data from "
+        f"{facility} shot {shot.shot_id}"
+        + (f", campaign {shot.campaign}" if shot.campaign else "")
+        + ". Published under CC-BY-4.0 by the UK Atomic Energy Authority."
+    )
+    zarr_url = dataset_metadata.s3_to_http(shot.url, shot.endpoint_url)
+    json_path = "/json/shots" if level == 1 else "/json/level2/shots"
+    parquet_path = "/parquet/shots" if level == 1 else "/parquet/level2/shots"
+    json_url = f"{SITE_URL}{json_path}/{shot.shot_id}"
+    parquet_url = f"{SITE_URL}{parquet_path}?filters=shot_id$eq:{shot.shot_id}"
+    response = templates.TemplateResponse(
+        request=request,
+        name="dataset_shot.html",
+        context={
+            "shot": shot,
+            "sources": sources,
+            "shot_title": shot_title,
+            "page_description": description,
+            "canonical_url": dataset_metadata.shot_page_url(SITE_URL, shot.shot_id, level),
+            "dcat_url": dataset_metadata.shot_jsonld_url(SITE_URL, shot.shot_id, level),
+            "license_url": dataset_metadata.LICENSE_URL,
+            "jsonld": jsonld,
+            "zarr_url": zarr_url,
+            "json_url": json_url,
+            "parquet_url": parquet_url,
+            "related_level": related_level,
+        },
+    )
+    response.headers["Cache-Control"] = "public, max-age=3600"
+    return response
+
+
+def _render_shot_dcat(db: Session, shot_id: int, level: int) -> Response:
+    shot, other_exists = _load_shot_for_landing(db, shot_id, level)
+    sources = list(shot.sources)
+    related_level_url = (
+        dataset_metadata.shot_page_url(SITE_URL, shot_id, 2 if level == 1 else 1)
+        if other_exists
+        else None
+    )
+    doc = jsonld_dcat.build_shot_dataset_dcat(
+        shot, sources, SITE_URL, level=level, related_level_url=related_level_url
+    )
+    return JSONResponse(
+        content=doc,
+        media_type="application/ld+json",
+        headers={"Cache-Control": "public, max-age=3600"},
+    )
+
+
+@app.get(
+    "/dataset/level1/shot/{shot_id}.jsonld",
+    description="DCAT 3 JSON-LD representation of a single Level 1 MAST shot.",
+)
+def get_level1_shot_dcat(shot_id: int, db: Session = Depends(get_db)):
+    return _render_shot_dcat(db, shot_id, level=1)
+
+
+@app.get(
+    "/dataset/level1/shot/{shot_id}",
+    response_class=HTMLResponse,
+    description="HTML landing page for a Level 1 MAST shot with embedded schema.org Dataset JSON-LD.",
+)
+def get_level1_shot_landing(
+    request: Request, shot_id: int, db: Session = Depends(get_db)
+):
+    return _render_shot_landing(request, db, shot_id, level=1)
+
+
+@app.get(
+    "/dataset/level2/shot/{shot_id}.jsonld",
+    description="DCAT 3 JSON-LD representation of a single Level 2 MAST shot.",
+)
+def get_level2_shot_dcat(shot_id: int, db: Session = Depends(get_db)):
+    return _render_shot_dcat(db, shot_id, level=2)
+
+
+@app.get(
+    "/dataset/level2/shot/{shot_id}",
+    response_class=HTMLResponse,
+    description="HTML landing page for a Level 2 MAST shot with embedded schema.org Dataset JSON-LD.",
+)
+def get_level2_shot_landing(
+    request: Request, shot_id: int, db: Session = Depends(get_db)
+):
+    return _render_shot_landing(request, db, shot_id, level=2)
+
 
 app.mount("/", StaticFiles(directory=docs_directory, html=True))

--- a/src/api/templates/base_landing.html
+++ b/src/api/templates/base_landing.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+
+<title>{% block title %}FAIR MAST{% endblock %}</title>
+
+<link rel="canonical" href="{{ canonical_url }}">
+{% if dcat_url %}
+<link rel="alternate" type="application/ld+json" href="{{ dcat_url }}" title="DCAT representation">
+{% endif %}
+
+<meta name="description" content="{{ page_description }}">
+
+<meta property="og:type" content="website">
+<meta property="og:title" content="{% block og_title %}{{ self.title() }}{% endblock %}">
+<meta property="og:description" content="{{ page_description }}">
+<meta property="og:url" content="{{ canonical_url }}">
+<meta property="og:site_name" content="FAIR MAST Data Archive">
+<meta name="twitter:card" content="summary">
+<meta name="twitter:title" content="{% block twitter_title %}{{ self.title() }}{% endblock %}">
+<meta name="twitter:description" content="{{ page_description }}">
+
+<script type="application/ld+json">
+{{ jsonld | tojson }}
+</script>
+
+<style>
+:root { --fg: #1a1a1a; --muted: #555; --accent: #1a4480; --rule: #ddd; }
+body { font: 16px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif; color: var(--fg); max-width: 880px; margin: 2rem auto; padding: 0 1.25rem; }
+header { border-bottom: 1px solid var(--rule); padding-bottom: 1rem; margin-bottom: 1.5rem; }
+header a { color: var(--accent); text-decoration: none; }
+h1 { font-size: 1.75rem; margin: 0 0 0.25rem; }
+h2 { font-size: 1.1rem; margin-top: 2rem; border-bottom: 1px solid var(--rule); padding-bottom: 0.25rem; }
+.subtitle { color: var(--muted); font-size: 0.95rem; }
+dl.meta { display: grid; grid-template-columns: max-content 1fr; gap: 0.4rem 1rem; margin: 0; }
+dl.meta dt { color: var(--muted); }
+dl.meta dd { margin: 0; }
+ul.parts { padding-left: 1.2rem; }
+ul.parts li { margin-bottom: 0.4rem; }
+a { color: var(--accent); }
+code { font-size: 0.9em; background: #f4f4f4; padding: 0.1em 0.3em; border-radius: 3px; }
+footer { margin-top: 3rem; padding-top: 1rem; border-top: 1px solid var(--rule); color: var(--muted); font-size: 0.85rem; }
+</style>
+</head>
+<body>
+<header>
+<a href="/">FAIR MAST Data Archive</a>
+</header>
+
+{% block content %}{% endblock %}
+
+<footer>
+<p>Licensed under <a href="{{ license_url }}">CC-BY-4.0</a>. Published by the UK Atomic Energy Authority. <a href="{{ dcat_url }}">DCAT representation</a> · <a href="/redoc">API docs</a></p>
+</footer>
+</body>
+</html>

--- a/src/api/templates/dataset_shot.html
+++ b/src/api/templates/dataset_shot.html
@@ -1,0 +1,53 @@
+{% extends "base_landing.html" %}
+
+{% block title %}{{ shot_title }} — FAIR MAST{% endblock %}
+
+{% block content %}
+<h1>{{ shot_title }}</h1>
+<p class="subtitle">{{ page_description }}</p>
+
+<h2>Metadata</h2>
+<dl class="meta">
+<dt>Shot ID</dt><dd><code>{{ shot.shot_id }}</code></dd>
+{% if shot.uuid %}<dt>UUID</dt><dd><code>{{ shot.uuid }}</code></dd>{% endif %}
+{% if shot.facility %}<dt>Facility</dt><dd>{{ shot.facility.value }}</dd>{% endif %}
+{% if shot.campaign %}<dt>Campaign</dt><dd>{{ shot.campaign }}</dd>{% endif %}
+{% if shot.timestamp %}<dt>Fired at</dt><dd>{{ shot.timestamp.isoformat() }}</dd>{% endif %}
+{% if shot.divertor_config %}<dt>Divertor config</dt><dd>{{ shot.divertor_config.value }}</dd>{% endif %}
+{% if shot.plasma_shape %}<dt>Plasma shape</dt><dd>{{ shot.plasma_shape.value }}</dd>{% endif %}
+{% if shot.current_range %}<dt>Current range</dt><dd>{{ shot.current_range.value }}</dd>{% endif %}
+{% if shot.heating %}<dt>Heating</dt><dd>{{ shot.heating }}</dd>{% endif %}
+{% if shot.commissioner %}<dt>Commissioner</dt><dd>{{ shot.commissioner.value }}</dd>{% endif %}
+<dt>License</dt><dd><a href="{{ license_url }}">CC-BY-4.0</a></dd>
+</dl>
+
+{% if shot.preshot_description or shot.postshot_description %}
+<h2>Investigator notes</h2>
+{% if shot.preshot_description %}<p><strong>Pre-shot:</strong> {{ shot.preshot_description }}</p>{% endif %}
+{% if shot.postshot_description %}<p><strong>Post-shot:</strong> {{ shot.postshot_description }}</p>{% endif %}
+{% endif %}
+
+<h2>Data access</h2>
+<ul>
+{% if zarr_url %}<li>Zarr store: <a href="{{ zarr_url }}"><code>{{ zarr_url }}</code></a></li>{% endif %}
+<li>JSON metadata: <a href="{{ json_url }}"><code>{{ json_url }}</code></a></li>
+<li>Parquet export: <a href="{{ parquet_url }}"><code>{{ parquet_url }}</code></a></li>
+<li>DCAT JSON-LD: <a href="{{ dcat_url }}"><code>{{ dcat_url }}</code></a></li>
+</ul>
+
+{% if related_level %}
+<h2>Related datasets</h2>
+<ul>
+<li><a href="{{ related_level.url }}">{{ related_level.label }}</a> — {{ related_level.relation }}</li>
+</ul>
+{% endif %}
+
+{% if sources %}
+<h2>Diagnostic sources ({{ sources|length }})</h2>
+<ul class="parts">
+{% for src in sources %}
+<li><strong>{{ src.name }}</strong>{% if src.description %} — {{ src.description }}{% endif %}</li>
+{% endfor %}
+</ul>
+{% endif %}
+{% endblock %}

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -1,4 +1,6 @@
+import datetime
 import os
+import uuid
 from pathlib import Path
 
 import pytest
@@ -13,6 +15,15 @@ from strawberry.extensions import SchemaExtension
 from src.api.create import create_db_and_tables
 from src.api.database import get_db
 from src.api.main import app, graphql_app
+from src.api.models import Level2ShotModel, ShotModel, SourceModel
+from src.api.types import (
+    Commissioner,
+    CurrentRange,
+    DivertorConfig,
+    Facility,
+    PlasmaShape,
+    Quality,
+)
 
 # Set up the database URL
 host = os.environ.get("DATABASE_HOST", "localhost")
@@ -24,7 +35,7 @@ SQLALCHEMY_DATABASE_TEST_URL = f"postgresql://root:root@{host}:5432/{TEST_DB_NAM
 @pytest.fixture(scope="session")
 def test_db(data_path):
     data_path = Path(data_path)
-    create_db_and_tables(data_path, SQLALCHEMY_DATABASE_TEST_URL, TEST_DB_NAME)
+    create_db_and_tables(str(data_path), SQLALCHEMY_DATABASE_TEST_URL, TEST_DB_NAME)
     engine = create_engine(SQLALCHEMY_DATABASE_TEST_URL, echo=True)
 
     TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
@@ -64,3 +75,60 @@ def override_get_db(test_db):
 def client():
     with TestClient(app) as client:
         yield client
+
+
+# Synthetic ShotModel/SourceModel factories for unit tests that don't need a
+# DB. `# type: ignore[call-arg]` suppresses pyright complaints about the ~180
+# Optional cpf_* fields on BaseShotModel which default to None at runtime but
+# look required to a strict type checker.
+SHOT_TIMESTAMP = datetime.datetime(2013, 8, 9, 14, 23, 11, tzinfo=datetime.timezone.utc)
+
+
+def make_shot(cls: type[ShotModel] | type[Level2ShotModel] = ShotModel):
+    return cls(  # type: ignore[call-arg]
+        shot_id=30420,
+        uuid=uuid.UUID("e6c5f29a-9b2a-5e54-9b32-7e8f1c0e1b1f"),
+        url="s3://mast/level1/shots/30420.zarr",
+        endpoint_url="https://s3.echo.stfc.ac.uk",
+        timestamp=SHOT_TIMESTAMP,
+        preshot_description="L-mode reference shot.",
+        postshot_description="Stable plasma.",
+        campaign="M9",
+        facility=Facility.mast,
+        divertor_config=DivertorConfig.conventional,
+        plasma_shape=PlasmaShape.connected_double_null,
+        current_range=CurrentRange._700kA,
+        commissioner=Commissioner.ukaea,
+        heating="NBI",
+        type_="dcat:Dataset",
+        title="Shot Dataset",
+        context_={},
+    )
+
+
+def make_source(name="AMC", description=None):
+    return SourceModel(  # type: ignore[call-arg]
+        shot_id=30420,
+        name=name,
+        title="Source Dataset",  # boilerplate server_default — should NOT be used as display name
+        description=description or f"{name} diagnostic.",
+        url=f"s3://mast/level1/shots/30420.zarr/{name}",
+        endpoint_url="https://s3.echo.stfc.ac.uk",
+        uuid=uuid.uuid5(uuid.NAMESPACE_OID, name),
+        quality=Quality.validated,
+        type_="dcat:Dataset",
+        context_={},
+    )
+
+
+@pytest.fixture
+def shot():
+    return make_shot()
+
+
+@pytest.fixture
+def sources():
+    return [
+        make_source("AMC", "Plasma current and magnetic equilibrium signals."),
+        make_source("AYC", "Electron temperature and density."),
+    ]

--- a/tests/api/test_jsonld_dcat.py
+++ b/tests/api/test_jsonld_dcat.py
@@ -1,0 +1,123 @@
+"""Unit tests for src/api/jsonld_dcat.py — no DB needed.
+
+Synthetic shot/source factories and the `shot` / `sources` fixtures live in
+tests/api/conftest.py.
+"""
+
+import pytest
+
+from src.api import dataset_metadata
+from src.api.jsonld_dcat import build_shot_dataset_dcat
+from src.api.models import Level2ShotModel
+
+from .conftest import make_shot
+
+SITE = "https://mastapp.site"
+
+
+def test_basic_shape(shot, sources):
+    doc = build_shot_dataset_dcat(shot, sources, SITE)
+    assert doc["@type"] == "dcat:Dataset"
+    assert doc["@id"] == "https://mastapp.site/dataset/level1/shot/30420"
+
+
+def test_context_has_required_prefixes(shot, sources):
+    doc = build_shot_dataset_dcat(shot, sources, SITE)
+    ctx = doc["@context"]
+    for prefix in ("dcat", "dct", "foaf", "schema", "xsd", "owl"):
+        assert prefix in ctx, f"missing prefix: {prefix}"
+
+
+def test_dcat_dataset_required_fields(shot, sources):
+    doc = build_shot_dataset_dcat(shot, sources, SITE)
+    for field in (
+        "dct:title",
+        "dct:description",
+        "dct:identifier",
+        "dct:license",
+        "dct:publisher",
+        "dcat:distribution",
+        "dct:isPartOf",
+    ):
+        assert field in doc, f"missing required field: {field}"
+
+
+def test_license_is_cc_by_4(shot, sources):
+    doc = build_shot_dataset_dcat(shot, sources, SITE)
+    assert doc["dct:license"]["@id"] == "https://creativecommons.org/licenses/by/4.0/"
+
+
+def test_distributions_use_https_not_s3(shot, sources):
+    doc = build_shot_dataset_dcat(shot, sources, SITE)
+    for dist in doc["dcat:distribution"]:
+        url = dist["dcat:accessURL"]["@id"]
+        assert not url.startswith("s3://"), f"accessURL should be HTTPS, got {url}"
+
+
+def test_temporal_is_period_of_time(shot, sources):
+    doc = build_shot_dataset_dcat(shot, sources, SITE)
+    temporal = doc["dct:temporal"]
+    assert temporal["@type"] == "dct:PeriodOfTime"
+    assert temporal["dcat:startDate"]["@type"] == "xsd:dateTime"
+    assert temporal["dcat:endDate"]["@type"] == "xsd:dateTime"
+
+
+def test_has_part_uses_source_name_not_boilerplate_title(shot, sources):
+    doc = build_shot_dataset_dcat(shot, sources, SITE)
+    titles = [p["dct:title"] for p in doc["dct:hasPart"]]
+    assert "Source Dataset" not in titles
+    assert titles == ["AMC", "AYC"]
+
+
+def test_level_appears_in_title(shot, sources):
+    doc_l1 = build_shot_dataset_dcat(shot, sources, SITE, level=1)
+    doc_l2 = build_shot_dataset_dcat(make_shot(Level2ShotModel), sources, SITE, level=2)
+    assert "(Level 1)" in doc_l1["dct:title"]
+    assert "(Level 2)" in doc_l2["dct:title"]
+
+
+def test_no_cross_link_when_related_url_omitted(shot, sources):
+    doc = build_shot_dataset_dcat(shot, sources, SITE)
+    assert "dct:source" not in doc
+    assert "dct:hasVersion" not in doc
+
+
+def test_level1_with_related_level_emits_has_version(shot, sources):
+    related = dataset_metadata.shot_page_url(SITE, 30420, level=2)
+    doc = build_shot_dataset_dcat(
+        shot, sources, SITE, level=1, related_level_url=related
+    )
+    assert doc["dct:hasVersion"]["@id"] == related
+    assert "dct:source" not in doc
+
+
+def test_level2_with_related_level_emits_dct_source():
+    shot = make_shot(Level2ShotModel)
+    related = dataset_metadata.shot_page_url(SITE, 30420, level=1)
+    doc = build_shot_dataset_dcat(
+        shot, [], SITE, level=2, related_level_url=related
+    )
+    assert doc["dct:source"]["@id"] == related
+    assert "dct:hasVersion" not in doc
+
+
+def test_url_differs_per_level(shot):
+    doc_l1 = build_shot_dataset_dcat(shot, [], SITE, level=1)
+    doc_l2 = build_shot_dataset_dcat(make_shot(Level2ShotModel), [], SITE, level=2)
+    assert doc_l1["@id"] == "https://mastapp.site/dataset/level1/shot/30420"
+    assert doc_l2["@id"] == "https://mastapp.site/dataset/level2/shot/30420"
+
+
+def test_jsonld_parses_with_rdflib(shot, sources):
+    """Sanity check: the DCAT graph round-trips through an RDF parser.
+
+    rdflib isn't a test dep — skip when it's not installed rather than
+    forcing it. Useful to run locally if you've installed it.
+    """
+    rdflib = pytest.importorskip("rdflib")
+    import json
+
+    doc = build_shot_dataset_dcat(shot, sources, SITE)
+    g = rdflib.Graph()
+    g.parse(data=json.dumps(doc), format="json-ld")
+    assert len(g) > 0

--- a/tests/api/test_jsonld_schemaorg.py
+++ b/tests/api/test_jsonld_schemaorg.py
@@ -1,0 +1,140 @@
+"""Unit tests for src/api/jsonld_schemaorg.py — no DB needed.
+
+Synthetic shot/source factories and the `shot` / `sources` fixtures live in
+tests/api/conftest.py.
+"""
+
+import datetime
+
+from src.api import dataset_metadata
+from src.api.jsonld_schemaorg import build_shot_dataset_jsonld
+from src.api.models import Level2ShotModel
+
+from .conftest import make_shot, make_source
+
+SITE = "https://mastapp.site"
+
+
+def test_basic_shape(shot, sources):
+    doc = build_shot_dataset_jsonld(shot, sources, SITE)
+    assert doc["@context"] == "https://schema.org"
+    assert doc["@type"] == "Dataset"
+    assert doc["@id"] == "https://mastapp.site/dataset/level1/shot/30420"
+    assert doc["url"] == doc["@id"]
+
+
+def test_required_google_fields_present(shot, sources):
+    doc = build_shot_dataset_jsonld(shot, sources, SITE)
+    for field in ("name", "description", "license", "identifier", "url", "publisher"):
+        assert field in doc, f"missing required field: {field}"
+
+
+def test_license_is_cc_by_4(shot, sources):
+    doc = build_shot_dataset_jsonld(shot, sources, SITE)
+    assert doc["license"] == "https://creativecommons.org/licenses/by/4.0/"
+
+
+def test_identifier_contains_shot_id_and_uuid(shot, sources):
+    doc = build_shot_dataset_jsonld(shot, sources, SITE)
+    propertyIDs = {ident["propertyID"] for ident in doc["identifier"]}
+    assert propertyIDs == {"shot_id", "uuid"}
+
+
+def test_distributions_use_https_not_s3(shot, sources):
+    doc = build_shot_dataset_jsonld(shot, sources, SITE)
+    for dist in doc["distribution"]:
+        assert not dist["contentUrl"].startswith("s3://"), (
+            f"distribution contentUrl should be HTTPS, got {dist['contentUrl']}"
+        )
+
+
+def test_temporal_coverage_is_iso8601_interval(shot, sources):
+    doc = build_shot_dataset_jsonld(shot, sources, SITE)
+    assert "/" in doc["temporalCoverage"]
+    start, end = doc["temporalCoverage"].split("/")
+    datetime.datetime.fromisoformat(start)
+    datetime.datetime.fromisoformat(end)
+
+
+def test_included_in_data_catalog(shot, sources):
+    doc = build_shot_dataset_jsonld(shot, sources, SITE)
+    assert doc["includedInDataCatalog"]["@id"] == "https://mastapp.site/catalog"
+    assert doc["isPartOf"] == "https://mastapp.site/catalog"
+
+
+def test_keywords_deduped(shot, sources):
+    doc = build_shot_dataset_jsonld(shot, sources, SITE)
+    assert len(doc["keywords"]) == len(set(doc["keywords"]))
+
+
+def test_variable_measured_uses_source_names_not_boilerplate_title(shot, sources):
+    doc = build_shot_dataset_jsonld(shot, sources, SITE)
+    names = [v["name"] for v in doc["variableMeasured"]]
+    assert "Source Dataset" not in names
+    assert names == ["AMC", "AYC"]
+
+
+def test_has_part_uses_source_name(shot, sources):
+    doc = build_shot_dataset_jsonld(shot, sources, SITE)
+    part_names = [p["name"] for p in doc["hasPart"]]
+    assert part_names == ["AMC", "AYC"]
+
+
+def test_variable_measured_capped_at_10(shot):
+    many = [make_source(f"SRC{i:02d}") for i in range(15)]
+    doc = build_shot_dataset_jsonld(shot, many, SITE)
+    assert len(doc["variableMeasured"]) == 10
+
+
+def test_no_cross_link_when_related_url_omitted(shot, sources):
+    doc = build_shot_dataset_jsonld(shot, sources, SITE)
+    assert "isBasedOn" not in doc
+    assert "subjectOf" not in doc
+
+
+def test_level1_with_related_level_emits_subject_of(shot, sources):
+    related = dataset_metadata.shot_page_url(SITE, 30420, level=2)
+    doc = build_shot_dataset_jsonld(
+        shot, sources, SITE, level=1, related_level_url=related
+    )
+    assert doc["subjectOf"]["@id"] == related
+    assert "isBasedOn" not in doc
+
+
+def test_level2_with_related_level_emits_is_based_on():
+    shot = make_shot(Level2ShotModel)
+    related = dataset_metadata.shot_page_url(SITE, 30420, level=1)
+    doc = build_shot_dataset_jsonld(
+        shot, [], SITE, level=2, related_level_url=related
+    )
+    assert doc["isBasedOn"]["@id"] == related
+    assert "subjectOf" not in doc
+
+
+def test_level_appears_in_name_and_description(shot, sources):
+    doc_l1 = build_shot_dataset_jsonld(shot, sources, SITE, level=1)
+    doc_l2 = build_shot_dataset_jsonld(
+        make_shot(Level2ShotModel), sources, SITE, level=2
+    )
+    assert "(Level 1)" in doc_l1["name"]
+    assert "(Level 2)" in doc_l2["name"]
+    assert doc_l1["description"].startswith("Level 1")
+    assert doc_l2["description"].startswith("Level 2")
+
+
+def test_level_appears_in_keywords(shot, sources):
+    doc_l1 = build_shot_dataset_jsonld(shot, sources, SITE, level=1)
+    doc_l2 = build_shot_dataset_jsonld(
+        make_shot(Level2ShotModel), sources, SITE, level=2
+    )
+    assert "Level 1" in doc_l1["keywords"]
+    assert "Level 2" in doc_l2["keywords"]
+
+
+def test_url_differs_per_level(shot):
+    doc_l1 = build_shot_dataset_jsonld(shot, [], SITE, level=1)
+    doc_l2 = build_shot_dataset_jsonld(
+        make_shot(Level2ShotModel), [], SITE, level=2
+    )
+    assert doc_l1["url"] == "https://mastapp.site/dataset/level1/shot/30420"
+    assert doc_l2["url"] == "https://mastapp.site/dataset/level2/shot/30420"

--- a/tests/api/test_landing_pages.py
+++ b/tests/api/test_landing_pages.py
@@ -1,0 +1,96 @@
+"""Integration tests for the per-shot dataset landing-page routes.
+
+Uses the existing TestClient + override_get_db fixtures from conftest.py,
+which spins up a test postgres and ingests the mock data. Hits shot IDs
+that the JSON tests confirm exist in the mock set (e.g. 11699).
+"""
+
+import json
+import re
+
+import pytest
+
+# override_get_db patches app.dependency_overrides as a side effect; it's
+# applied to every test here rather than passed as an (unused) argument.
+pytestmark = pytest.mark.usefixtures("override_get_db")
+
+KNOWN_SHOT_ID = 11699  # exists in mock_data per tests/api/test_json.py
+MISSING_SHOT_ID = 99999999
+
+
+def _extract_jsonld(html: str) -> dict:
+    m = re.search(
+        r'<script type="application/ld\+json">\s*(.*?)\s*</script>',
+        html,
+        re.DOTALL,
+    )
+    assert m, "no JSON-LD <script> block found in HTML"
+    return json.loads(m.group(1))
+
+
+# --- Level 1 HTML ---------------------------------------------------------
+
+
+def test_level1_landing_returns_html(client):
+    response = client.get(f"/dataset/level1/shot/{KNOWN_SHOT_ID}")
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/html")
+
+
+def test_level1_landing_has_embedded_schema_org_jsonld(client):
+    response = client.get(f"/dataset/level1/shot/{KNOWN_SHOT_ID}")
+    doc = _extract_jsonld(response.text)
+    assert doc["@context"] == "https://schema.org"
+    assert doc["@type"] == "Dataset"
+    assert "Level 1" in doc["name"]
+    assert doc["license"] == "https://creativecommons.org/licenses/by/4.0/"
+
+
+def test_level1_landing_has_canonical_and_alternate_links(client):
+    response = client.get(f"/dataset/level1/shot/{KNOWN_SHOT_ID}")
+    assert 'rel="canonical"' in response.text
+    assert 'rel="alternate"' in response.text
+    assert f"/dataset/level1/shot/{KNOWN_SHOT_ID}.jsonld" in response.text
+
+
+def test_level1_landing_404_for_missing_shot(client):
+    response = client.get(f"/dataset/level1/shot/{MISSING_SHOT_ID}")
+    assert response.status_code == 404
+
+
+# --- Level 1 DCAT JSON-LD -------------------------------------------------
+
+
+def test_level1_dcat_endpoint_returns_jsonld(client):
+    response = client.get(f"/dataset/level1/shot/{KNOWN_SHOT_ID}.jsonld")
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("application/ld+json")
+    doc = response.json()
+    assert doc["@type"] == "dcat:Dataset"
+    assert "Level 1" in doc["dct:title"]
+    assert doc["dct:license"]["@id"] == "https://creativecommons.org/licenses/by/4.0/"
+
+
+def test_level1_dcat_404_for_missing_shot(client):
+    response = client.get(f"/dataset/level1/shot/{MISSING_SHOT_ID}.jsonld")
+    assert response.status_code == 404
+
+
+# --- Level 2 (routes exist regardless of mock data availability) ----------
+
+
+def test_level2_landing_route_exists(client):
+    """The route handler is registered; a missing shot returns 404 (not
+    a routing 404). If level2 mock data exists, returns 200.
+    """
+    response = client.get(f"/dataset/level2/shot/{MISSING_SHOT_ID}")
+    assert response.status_code == 404
+    detail = response.json()["detail"]
+    assert "Level 2" in detail
+
+
+def test_level2_dcat_route_exists(client):
+    response = client.get(f"/dataset/level2/shot/{MISSING_SHOT_ID}.jsonld")
+    assert response.status_code == 404
+
+


### PR DESCRIPTION
## Summary

Makes MAST shots discoverable on Google Dataset Search and DCAT-AP harvesters by
serving crawlable per-shot landing pages. The archive previously exposed only
JSON/GraphQL APIs, which search crawlers don't index.

- **HTML landing pages** at `/dataset/level{1,2}/shot/{id}` embedding
  `schema.org/Dataset` JSON-LD — what Google Dataset Search indexes.
- **DCAT 3 JSON-LD** at sibling `.jsonld` URLs for FAIR harvesters (B2FIND,
  OpenAIRE, re3data, EOSC), linked via `<link rel="alternate">`.
- **Level 1 and Level 2 as distinct datasets**, cross-linked via
  `schema:isBasedOn`/`dct:source` (L2→L1) and `schema:subjectOf`/`dct:hasVersion`
  (L1→L2) when both levels exist for a shot.
- `s3://` store URLs rewritten to HTTPS via the endpoint so crawlers/browsers can
  resolve them.
- All URLs derive from `SITE_URL` (env-driven `VIRTUAL_HOST`); no hardcoded domain.
- Uniform metadata (CC-BY-4.0 licence, UKAEA publisher/funder, keywords) lives as
  constants in `dataset_metadata.py` — no model migration.

### New files
- `src/api/dataset_metadata.py` — shared constants + URL helpers
- `src/api/jsonld_schemaorg.py` — schema.org Dataset builder
- `src/api/jsonld_dcat.py` — DCAT 3 builder
- `src/api/templates/{base_landing,dataset_shot}.html` — page templates
- `tests/api/test_jsonld_{schemaorg,dcat}.py`, `test_landing_pages.py`

### Out of scope (follow-ups)
- Standalone per-source landing pages (sources are nested `hasPart` fragments for now)
- Catalogue page (`/catalog`), `sitemap.xml`, `robots.txt`
- DOI minting, DCAT-AP profile conformance
- Google Search Console verification + sitemap submission (one-time ops)

## Screenshot

<img width="942" height="1325" alt="image" src="https://github.com/user-attachments/assets/58f61e83-9dd3-4030-994e-fb9d7d9106dc" />

## Test plan

- [x] `uv run pytest tests/api/test_jsonld_schemaorg.py tests/api/test_jsonld_dcat.py` — 29 unit tests pass (1 rdflib round-trip skipped unless rdflib installed)
- [x] Manually loaded `/dataset/level1/shot/30421` locally — renders with full metadata, HTTPS zarr URL, and the Level 2 cross-link (see screenshot)
- [ ] `uv run pytest tests/api/test_landing_pages.py` — integration tests (need postgres + mock data; run in CI)
- [ ] Validate the embedded JSON-LD in the [Google Rich Results Test](https://search.google.com/test/rich-results) after deploy to a public URL
- [ ] Confirm `/dataset/level1/shot/<id>.jsonld` returns valid DCAT
