### PR TITLE
WIP: Cache notebook execution (S3) to stop flaky docs deploys

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -13,6 +13,8 @@ env:
   GRAFANA_USER: ${{ secrets.GRAFANA_USERNAME }}
   GRAFANA_PASSWORD: ${{ secrets.GRAFANA_PASSWORD }}
   WEBHOOK_URL:  ${{ secrets.WEBHOOK_URL }}
+  STFC_ACCESS_KEY: ${{ secrets.STFC_ACCESS_KEY }}
+  STFC_SECRET_ACCESS_KEY: ${{ secrets.STFC_SECRET_ACCESS_KEY }}
   NGINX_CONFIG_PATH: ./nginx.conf
   CERTBOT_COMMAND: "/bin/sh -c 'certbot certonly --webroot --webroot-path /var/www/certbot/ --non-interactive -d mastapp.site -d www.mastapp.site --agree-tos --register-unsafely-without-email; while :; do certbot renew; sleep 12h; done'"  
 
@@ -31,7 +33,7 @@ jobs:
           username: ${{ secrets.REMOTE_USERNAME }}
           key: ${{ secrets.REMOTE_PRIV_KEY }}
           port: ${{ secrets.REMOTE_PORT }}
-          envs: PRODUCTION,POSTGRES_PASSWORD,POSTGRES_USER,PGADMIN_USER,PGADMIN_PASSWORD,NGINX_CONFIG_PATH,CERTBOT_COMMAND,GRAFANA_USER,GRAFANA_PASSWORD,WEBHOOK_URL
+          envs: PRODUCTION,POSTGRES_PASSWORD,POSTGRES_USER,PGADMIN_USER,PGADMIN_PASSWORD,NGINX_CONFIG_PATH,CERTBOT_COMMAND,GRAFANA_USER,GRAFANA_PASSWORD,WEBHOOK_URL,STFC_ACCESS_KEY,STFC_SECRET_ACCESS_KEY
           script: |
             cd /srv/fair-mast/
             git pull
@@ -40,7 +42,17 @@ jobs:
             uv venv .docs-venv --python 3.12
             source .docs-venv/bin/activate
             uv pip install -r docs-requirements.txt
+            # Restore the shared notebook execution cache; unchanged notebooks are
+            # served from cache rather than re-executed against the live API / object
+            # store. (Objects under fairmast-docs/ are not public-read, so use creds.)
+            mkdir -p docs/built_docs/_build/.jupyter_cache
+            AWS_ACCESS_KEY_ID=$STFC_ACCESS_KEY AWS_SECRET_ACCESS_KEY=$STFC_SECRET_ACCESS_KEY \
+              s5cmd --endpoint-url https://s3.echo.stfc.ac.uk \
+              cp 's3://mast/fairmast-docs/jupyter_cache/*' docs/built_docs/_build/.jupyter_cache/ || true
             jb build docs --path-output docs/built_docs
+            AWS_ACCESS_KEY_ID=$STFC_ACCESS_KEY AWS_SECRET_ACCESS_KEY=$STFC_SECRET_ACCESS_KEY \
+              s5cmd --endpoint-url https://s3.echo.stfc.ac.uk \
+              sync docs/built_docs/_build/.jupyter_cache/ 's3://mast/fairmast-docs/jupyter_cache/'
             docker compose -f dev/docker/docker-compose.yml -f dev/docker/docker-compose-prod.yml up --build --remove-orphans --force-recreate -d
 
 

--- a/.github/workflows/deploy_pages.yml
+++ b/.github/workflows/deploy_pages.yml
@@ -15,13 +15,32 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Build the site
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.STFC_ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.STFC_SECRET_ACCESS_KEY }}
       run: |
         pip install --upgrade pip
         pip install uv
         uv venv .docs-venv --python 3.12
         source .docs-venv/bin/activate
         uv pip install -r docs-requirements.txt
+        # Restore the notebook execution cache. Unchanged notebooks are then served
+        # from cache instead of re-executing against the live API / S3, which keeps
+        # the deploy deterministic and off the flaky network path. (Objects under
+        # fairmast-docs/ are not public-read, so this needs credentials.)
+        mkdir -p _site/_build/.jupyter_cache
+        s5cmd --endpoint-url https://s3.echo.stfc.ac.uk \
+          cp 's3://mast/fairmast-docs/jupyter_cache/*' _site/_build/.jupyter_cache/ || true
         jb build docs --path-output _site
+    - name: Save notebook execution cache
+      if: always()
+      run: |
+        source .docs-venv/bin/activate
+        s5cmd --endpoint-url https://s3.echo.stfc.ac.uk \
+          sync _site/_build/.jupyter_cache/ 's3://mast/fairmast-docs/jupyter_cache/'
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.STFC_ACCESS_KEY }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.STFC_SECRET_ACCESS_KEY }}
     - name: Upload artifact
       uses: actions/upload-pages-artifact@v3
       with:

--- a/README.md
+++ b/README.md
@@ -110,6 +110,11 @@ uv pip install -r docs-requirements.txt
 jb build docs --path-output docs/built_docs
 ```
 
+Notebook execution is cached: only notebooks whose source has changed are re-run,
+and the rest reuse cached outputs under `docs/built_docs/_build/.jupyter_cache`.
+Delete that directory to force a full re-execution against the live API and
+object store.
+
 Once it has finished running simply restart (or run for the first time) the docker containers using:
 
 ```bash

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,11 @@ uv pip install -r docs-requirements.txt
 jb build docs --path-output docs/built_docs
 ```
 
+Notebook execution is cached: only notebooks whose source has changed are re-run,
+and the rest reuse cached outputs under `docs/built_docs/_build/.jupyter_cache`.
+Delete that directory to force a full re-execution against the live API and
+object store.
+
 Then (re)start the docker containers to serve the built docs:
 
 ```bash

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -23,7 +23,7 @@ execute:
   # cells don't time out. This is a ceiling, not a target - fast cells are
   # unaffected.
   timeout: 300
-  execute_notebooks: force
+  execute_notebooks: cache
   exclude_patterns:
     - 'data'
     - 'data/*'

--- a/docs/graphql_api.ipynb
+++ b/docs/graphql_api.ipynb
@@ -64,8 +64,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Select your transport with a defined url endpoint\n",
-    "transport = RequestsHTTPTransport(url=API_URL)\n",
+    "# Select your transport with a defined url endpoint.\n",
+    "# retries makes schema introspection resilient to a momentary API blip\n",
+    "# (e.g. the server restarting) during a docs build.\n",
+    "transport = RequestsHTTPTransport(url=API_URL, retries=3)\n",
     "# Create a GraphQL client using the defined transport\n",
     "client = Client(transport=transport, fetch_schema_from_transport=True)"
    ]

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -13,13 +13,13 @@ import ujson
 from fastapi import Depends, FastAPI, HTTPException, Query, Request, Response, status
 from fastapi.encoders import jsonable_encoder
 from fastapi.exceptions import RequestValidationError
+from fastapi.middleware.httpsredirect import HTTPSRedirectMiddleware
 from fastapi.responses import JSONResponse, StreamingResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 from fastapi_pagination import add_pagination
 from fastapi_pagination.cursor import CursorPage
 from fastapi_pagination.ext.sqlalchemy import paginate
-from fastapi.middleware.httpsredirect import HTTPSRedirectMiddleware
 from sqlalchemy.orm import Session
 from strawberry.asgi import GraphQL
 from strawberry.http import GraphQLHTTPResponse


### PR DESCRIPTION
**Status: WIP / draft** — awaiting review, and the first post-merge CI run to confirm cross-platform cache reuse (macOS-seeded cache → Linux runner).

## Problem

Docs builds run `execute_notebooks: force`, so every build — GitHub Pages **and** the mastapp.site CD — re-executes all notebooks against the live GraphQL API and S3. That makes deploys flaky and has repeatedly published `main` with tracebacks:

- **Timeouts** on slow-network runs (the remote zarr fetches).
- **Races**: pushing to `main` fires CD (which force-recreates the API containers) and Pages at the same second, so introspection hits the server mid-restart → dropped connection.

Different notebooks fail on different runs depending on network/server state — re-running is whack-a-mole.

## Solution

Cache the notebook **execution** (not the rendered HTML) and persist it in S3, so a normal deploy re-executes nothing.

| Commit | Change |
|---|---|
| Cache notebook execution instead of re-running on every build | `execute_notebooks: force` → `cache` |
| Persist the notebook execution cache in S3 for the Pages build | restore/save `jupyter_cache` around the build (authed) |
| Share the notebook execution cache in S3 from the CD build | mastapp.site build uses the same cache |
| Retry GraphQL introspection on transient failures | `retries=3` on the gql transport |

Cache lives STFC s3 (~5 MB). GitHub's `actions/cache` was rejected because its 7-day eviction would leave a cold build almost every time given the infrequent deploy cadence.

### Behaviour after this

- **Unchanged notebooks** → served from cache, **zero** live calls → deterministic, no timeouts/races.
- **A changed notebook** → only that one re-executes (with retries), then re-cached.
- **Data drift, notebook unchanged** → serves last-good output; a refresh is a deliberate act, not a broken `main`.

## Validation (local)

- Cache reuse across a fresh workspace (the CI/S3 scenario): 7 cached notebooks reused, **0 executions**; only the uncached one ran.
- Failed notebook is **retried and self-heals** on the next build (not stuck).
- S3 authed save (`sync`) + restore (`cp`) round-trip — all cache files intact.
- Anon read returns 403 on `fairmast-docs/` → restore uses credentials (the `STFC_ACCESS_KEY` secrets).
- Kernel is `python3` everywhere and cached outputs are platform-independent → macOS-seeded cache is valid for the Linux runner.

The real prefix is **already seeded** with a complete current cache, so the first deploy is warm (0 executions) from the start.

## Still to do

- [ ] Review.
- [ ] First post-merge CI run to confirm end-to-end cross-platform reuse on the runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)